### PR TITLE
:memo: It's Sass, not SASS.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -22,7 +22,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 --------------------------------------------------------------------
 
 This package was derived from a TextMate bundle located at
-https://github.com/alexsancho/SASS.tmbundle and distributed under the following
+https://github.com/alexsancho/Sass.tmbundle and distributed under the following
 license, located in `LICENSE.md`:
 
 Copyright (c) 2012 Alex Sancho, http://alexsancho.name/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# SASS/SCSS language support in Atom
+# Sass/SCSS language support in Atom
 
-Adds syntax highlighting and snippets to SASS/SCSS files in Atom.
+Adds syntax highlighting and snippets to Sass/SCSS files in Atom.
 
 Originally [converted](http://atom.io/docs/latest/converting-a-text-mate-bundle)
-from the [SASS TextMate bundle](https://github.com/alexsancho/SASS.tmbundle).
+from the [Sass TextMate bundle](https://github.com/alexsancho/SASS.tmbundle).
 
 Contributions are greatly appreciated. Please fork this repository and open a
 pull request to add snippets, make grammar tweaks, etc.

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -4,7 +4,7 @@
 ]
 'foldingStartMarker': '^\\s*([-%#\\:\\.\\w\\=].*)\\s$'
 'foldingStopMarker': '^\\s*$'
-'name': 'SASS'
+'name': 'Sass'
 'patterns': [
   {
     'begin': '^(\\!|\\$)([a-zA-Z0-9_-]+)\\s*((?:\\|\\|)?=|:)'

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1,4 +1,4 @@
-'comment': 'SCSS Version 2 Grammar by Mario "Kuroir" Ricalde (http://kuroir.com)'
+'comment': 'Sass Version 2 Grammar by Mario "Kuroir" Ricalde (http://kuroir.com)'
 'fileTypes': [
   'scss'
   'css.scss'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-sass",
   "version": "0.8.0",
-  "description": "SASS/SCSS language support in Atom",
+  "description": "Sass/SCSS language support in Atom",
   "license": "MIT",
   "engines": {
     "atom": "*",


### PR DESCRIPTION
Well, after disappointedly learning that Atom uses LESS internally, I figure, it can at least properly capitalize our dearest language, Sass.

Also, probably needs more refactor as "SCSS" isn't really a language and is just standard "Sass", but the indented syntax (with the .sass extension) is typically referred to as "Sass (indented)". But, that's for another commit.
