### PR TITLE
Added `will-change` propriety

### DIFF
--- a/scoped-properties/language-sass.cson
+++ b/scoped-properties/language-sass.cson
@@ -171,6 +171,7 @@
       'white-space'
       'widows'
       'width'
+      'will-change'
       'word-break'
       'word-spacing'
       'word-wrap'


### PR DESCRIPTION
The new CSS propriety `will-change` is not recognised and correctly highlighted.

Proof:
![will-change](http://i.imgur.com/QmmNfd3.png)

In this theme should be like:
![expected](http://i.imgur.com/WO23ZCp.png)

Added to the list of proprieties.
