### PR TITLE
fix punctuation selector for rgb values

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -610,7 +610,7 @@
     'captures':
       '1':
         'name': 'punctuation.definition.constant.scss'
-    'match': '#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})\\b'
+    'match': '(#)([0-9a-fA-F]{3}|[0-9a-fA-F]{6})\\b'
     'name': 'constant.other.color.rgb-value.scss'
   'constant_important':
     'match': '\\!important'


### PR DESCRIPTION
fixes #27 

Somehow somewhere the braces around # must've gone missing, because the capture was already there.

![screen shot 2014-12-03 at 22 37 01](https://cloud.githubusercontent.com/assets/2543659/5289299/f19ee26c-7b3c-11e4-8c0b-fc61babeed03.png)
