### PR TITLE
Allow underscore character in the extend function

### DIFF
--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -75,7 +75,7 @@
         'name': 'variable.other.sass'
       '3':
         'name': 'invalid.illegal.punctuation.sass'
-    'match': '^\\s*(@extend)\\s+([.*&#%a-zA-Z][-:.*&#a-zA-Z]*)\\s*(;)?\\s*$'
+    'match': '^\\s*(@extend)\\s+([.*&#%a-zA-Z][-_:.*&#a-zA-Z]*)\\s*(;)?\\s*$'
     'name': 'meta.function.extend.sass'
   }
   {


### PR DESCRIPTION
So this will get highlighted:

`@extend simple_card`

Note: It's my first contribution to an atom repository, so be gentle. I figured it's better to submit a pull request than to just open an issue and wait for someone to solve it. I also don't know how to test it, or if there needs to be written tests.
