### PR TITLE
SASS completion selector setting doesn't match how the grammar tokenize the buffer

### DIFF
--- a/settings/language-sass.cson
+++ b/settings/language-sass.cson
@@ -6,7 +6,7 @@
     'commentStart': '// '
     'increaseIndentPattern': '(^.*\\{[^}]*$)'
     'decreaseIndentPattern': '^\\s*\\}'
-'.source.sass .meta.property-list, .source.css.scss .meta.property-list':
+'.source.sass .meta.selector, .source.css.scss .meta.property-list':
   'editor':
     'completions': [
       'azimuth'


### PR DESCRIPTION
With the following snippet in a sass file, the cursor positioned at the end of `back`, the completion never provides the properties names: 

```sass
body 
  back
```
Autocomplete and Autocomplete+ both use the `editor.completion` field from the package settings, which use the following selector `.source.sass .meta.property-list` for sass completion of properties name. 
Sadly, there's no `property-list` class when typing a property in a selector, instead the grammar use `.meta.selector.css` when typing the beginning of a property name.

I'm not sure if replacing `.source.sass .meta.property-list` by `.source.sass .meta.selector` in the setting is the right way of solving that issue. If you think we can solve it like that I can take care of creating a PR  for that.

cc/ @kevinsawicki 
