### PR TITLE
Expand background to background, not background-image

### DIFF
--- a/snippets/language-sass.cson
+++ b/snippets/language-sass.cson
@@ -2,9 +2,9 @@
   '!important':
     'prefix': '!'
     'body': '!important${1:;}$0'
-  'background-color: hex':
+  'background: hex':
     'prefix': 'background'
-    'body': 'background-color: #${1:DDD};$0'
+    'body': 'background: #${1:DDD};$0'
   'clear: value':
     'prefix': 'clear'
     'body': 'clear: ${1:both};$0'


### PR DESCRIPTION
The CSS performance of `background` over `background-color` seems like a valid argument.

Fixes #13.