### PR TITLE
Small patches

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -196,7 +196,7 @@
     'name': 'meta.at-rule.for.scss'
     'patterns': [
       {
-        'match': '(\\=\\=|\\!\\=|\\<\\=|\\>\\=|\\<|\\>|from|through)'
+        'match': '(\\=\\=|\\!\\=|\\<\\=|\\>\\=|\\<|\\>|from|to|through)'
         'name': 'keyword.control.operator'
       }
       {

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -170,7 +170,7 @@
   'at_rule_fontface':
     'patterns': [
       {
-        'begin': '^\\s*((@)font-face)\\s*(?=\\{)'
+        'begin': '^\\s*((@)font-face\\b)'
         'beginCaptures':
           '1':
             'name': 'keyword.control.at-rule.fontface.scss'


### PR DESCRIPTION
- `to` is also a keyword in `@for` ([source](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#_10))
- most other at-rules are highlighted as soon as their written, so now `@font-face` does the same