### PR TITLE
Add support for the `@error` directive

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -530,7 +530,7 @@
       }
     ]
   'at_rule_warn':
-    'begin': '\\s*((@)(warn|debug)\\b)\\s*'
+    'begin': '\\s*((@)(warn|debug|error)\\b)\\s*'
     'captures':
       '1':
         'name': 'keyword.control.warn.scss'


### PR DESCRIPTION
It's pretty much the same as `@warn` except `@error` does throw.

http://sass-lang.com/documentation/file.SASS_REFERENCE.html#_7