### PR TITLE
Fix Comment Lines Leaking to the Next Line

### DIFF
--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -319,7 +319,7 @@
   'comment-line':
     'begin': '^(\\s*)(\\/\\/)'
     'captures':
-      '0':
+      '2':
         'name': 'punctuation.definition.comment.sass'
     'end': '\\n'
     'name': 'comment.sass'

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -119,6 +119,9 @@
     'name': 'meta.selector.css'
     'patterns': [
       {
+        'include': '#comment-line'
+      }
+      {
         'include': '#comment-block'
       }
       {
@@ -185,6 +188,9 @@
         'name': 'entity.other.attribute-name.parent-selector-suffix.css.sass'
       }
     ]
+  }
+  {
+    'include': '#comment-line'
   }
   {
     'include': '#comment-block'
@@ -310,12 +316,19 @@
   }
 ]
 'repository':
-  'comment-block':
-    'begin': '^(\\s*)(\\/\\/|\\/\\*)'
+  'comment-line':
+    'begin': '^(\\s*)(\\/\\/)'
     'captures':
       '0':
         'name': 'punctuation.definition.comment.sass'
-    'end': '^(?!\\1\\s)'
+    'end': '\\n'
+    'name': 'comment.sass'
+  'comment-block':
+    'begin': '^(\\s*)(\\/\\*)'
+    'captures':
+      '0':
+        'name': 'punctuation.definition.comment.sass'
+    'end': '\\*\\/'
     'name': 'comment.sass'
   'property-value':
     'begin': '(:)?\\s?+'

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -208,3 +208,25 @@ describe 'SCSS grammar', ->
       expect(tokens[16]).toEqual value: 'min-width', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'support.type.property-name.media.css']
       expect(tokens[18]).toEqual value: ' 700', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'constant.numeric.scss']
       expect(tokens[19]).toEqual value: 'px', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.other.unit.scss']
+
+describe 'Sass Grammar', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage('language-sass')
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName('source.sass')
+
+  describe 'comments', ->
+    it "doesn't confuse the next line as a comment", ->
+      lines = grammar.tokenizeLines """
+        // hello, world
+        $some-variable: 1
+      """
+
+      expect(lines[0][0]).toEqual value: '//', scopes: ['source.sass', 'comment.sass', 'punctuation.definition.comment.sass']
+      expect(lines[0][1]).toEqual value: ' hello, world', scopes: ['source.sass', 'comment.sass']
+      expect(lines[0][2]).toEqual value: '', scopes: ['source.sass', 'comment.sass']
+      expect(lines[1][0]).toEqual value: '$', scopes: ['source.sass', 'meta.variable-declaration.sass', 'punctuation.definition.entity.sass']


### PR DESCRIPTION
Comment lines would leak to the next line because of an awkward ending regular expressions.  Also splits the comment lines and comment blocks.

Fixes #67.