### PR TITLE
Update variable setting scope

### DIFF
--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -15,7 +15,7 @@
       '2':
         'name': 'variable.other.sass'
       '3':
-        'name': 'punctuation.definition.entity.sass'
+        'name': 'punctuation.separator.operator.sass'
     'end': '(;)?$'
     'endCaptures':
       '1':

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1129,11 +1129,11 @@
     'begin': '\\s*(\\$[A-Za-z0-9_-]+\\b)\\s*(\\:)\\s*'
     'captures':
       '1':
-        'name': 'variable'
+        'name': 'variable.scss'
       '2':
-        'name': 'punctuation'
+        'name': 'punctuation.separator.key-value.scss'
     'end': '\\s*(?=\\;)'
-    'name': 'meta.set.variable'
+    'name': 'meta.set.variable.scss'
     'patterns': [
       {
         'include': '#property_values'

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -208,3 +208,12 @@ describe 'SCSS grammar', ->
       expect(tokens[16]).toEqual value: 'min-width', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'support.type.property-name.media.css']
       expect(tokens[18]).toEqual value: ' 700', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'constant.numeric.scss']
       expect(tokens[19]).toEqual value: 'px', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.other.unit.scss']
+
+  describe 'variable setting', ->
+    it 'parses all tokens', ->
+      {tokens} = grammar.tokenizeLine '$font-size: $normal-font-size;'
+
+      expect(tokens[0]).toEqual value: '$font-size', scopes: ['source.css.scss', 'meta.set.variable.scss', 'variable.scss']
+      expect(tokens[1]).toEqual value: ':', scopes: ['source.css.scss', 'meta.set.variable.scss', 'punctuation.separator.key-value.scss']
+      expect(tokens[2]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.set.variable.scss']
+      expect(tokens[3]).toEqual value: '$normal-font-size', scopes: ['source.css.scss', 'meta.set.variable.scss', 'variable.scss', 'variable.scss']


### PR DESCRIPTION
Current the `:` for variable setting is only parsed as `punctuation`.

This PR update the scope of `:` for sass and scss. It also adds `.scss` to scss grammar.