### PR TITLE
Tokenize closing attribute-selector bracket

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -987,7 +987,7 @@
   'selector_attribute':
     'captures':
       '1':
-        'name': 'punctuation.definition.entity.scss'
+        'name': 'punctuation.definition.attribute-selector.begin.bracket.square.scss'
       '2':
         'name': 'entity.other.attribute-name.attribute.scss'
       '3':
@@ -1000,6 +1000,8 @@
         'name': 'punctuation.definition.string.begin.scss'
       '7':
         'name': 'punctuation.definition.string.end.scss'
+      '8':
+        'name': 'punctuation.definition.attribute-selector.end.bracket.square.scss'
     'match': '(?i)(\\[)\\s*(-?[_a-z\\\\[[:^ascii:]]][_a-z0-9\\-\\\\[[:^ascii:]]]*)(?:\\s*([~|^$*]?=)\\s*(?:(-?[_a-z\\\\[[:^ascii:]]][_a-z0-9\\-\\\\[[:^ascii:]]]*)|((?>([\'"])(?:[^\\\\]|\\\\.)*?(\\6)))))?\\s*(\\])'
     'name': 'meta.attribute-selector.scss'
   'selector_class':

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -206,6 +206,17 @@ describe 'SCSS grammar', ->
       expect(tokens[1]).toEqual value: ':', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
       expect(tokens[2]).toEqual value: 'nth-child(2n-1)', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css']
 
+  describe "attribute selectors", ->
+    it "parses them correctly", ->
+      {tokens} = grammar.tokenizeLine '[something="1"]'
+
+      expect(tokens[0]).toEqual value: '[', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'punctuation.definition.attribute-selector.begin.bracket.square.scss']
+      expect(tokens[1]).toEqual value: 'something', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'entity.other.attribute-name.attribute.scss']
+      expect(tokens[2]).toEqual value: '=', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'punctuation.separator.operator.scss']
+      expect(tokens[3]).toEqual value: '"', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'string.quoted.double.attribute-value.scss', 'punctuation.definition.string.begin.scss']
+      expect(tokens[5]).toEqual value: '"', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'string.quoted.double.attribute-value.scss', 'punctuation.definition.string.end.scss']
+      expect(tokens[6]).toEqual value: ']', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'punctuation.definition.attribute-selector.end.bracket.square.scss']
+
   describe "keyframes", ->
     it "parses the from and to properties", ->
       tokens = grammar.tokenizeLines """


### PR DESCRIPTION
Looks like it may have just been accidentally removed or forgotten, as the capture group was already there.

Fixes #39