### PR TITLE
Give nth-* pseudo-classes their own capture regex

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1012,7 +1012,7 @@
     'match': '\\b(a|abbr|acronym|address|area|article|aside|audio|b|base|bdi|bdo|big|blockquote|body|br|button|canvas|caption|circle|cite|code|col|colgroup|data|datalist|dd|del|details|dfn|dialog|div|dl|dt|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|g|(h[1-6])|head|header|hgroup|hr|html|i|iframe|img|image|input|ins|kbd|keygen|label|legend|li|line(?!-)|link|main|map|mark|menu|menuitem|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|path|polygon|polyline|pre|progress|q|rb|rect|rp|rt|rtc|ruby|s|samp|script|section|select|small|source|span|strike|strong|style|sub|summary|sup|svg|table(?!-)|tbody|td|template|text(?!-)|textarea|textpath|tfoot|th|thead|time|title|tr|track|tspan|tt|u|ul|var|video|wbr)\\b'
     'name': 'entity.name.tag.scss'
   'selector_custom':
-    'match': '\\b([a-zA-Z0-9]+(-[a-zA-Z0-9]+)+)(?=\\.|\\s++[^:]|\\s*[,{]|:(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|nth-child()|nth-last-child()|nth-of-type()|nth-last-of-type()|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid)(\\([0-9A-Za-z]*\\))?)'
+    'match': '\\b([a-zA-Z0-9]+(-[a-zA-Z0-9]+)+)(?=\\.|\\s++[^:]|\\s*[,{]|:(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|nth-(child|last-child|of-type|last-of-type)|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid)(\\([0-9A-Za-z]*\\))?)'
     'name': 'entity.name.tag.custom.scss'
   'selector_id':
     'captures':
@@ -1030,11 +1030,44 @@
     'match': '(?<=&)[a-zA-Z0-9_-]+'
     'name': 'entity.other.attribute-name.parent-selector-suffix.scss'
   'selector_pseudo_class':
-    'captures':
-      '1':
-        'name': 'punctuation.definition.entity.css'
-    'match': '(:)\\b(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|nth-child()|nth-last-child()|nth-of-type()|nth-last-of-type()|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid)(\\([-+0-9A-Za-z]*\\))?'
-    'name': 'entity.other.attribute-name.pseudo-class.css'
+    'patterns': [
+      {
+        'begin': '(:)\\b(nth-(?:child|last-child|of-type|last-of-type))(\\()'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.entity.css'
+          '2':
+            'name': 'entity.other.attribute-name.pseudo-class.css'
+          '3':
+            'name': 'punctuation.definition.pseudo-class.begin.bracket.round.css'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.pseudo-class.end.bracket.round.css'
+        'patterns': [
+          {
+            'match': '\\d+'
+            'name': 'constant.numeric.scss'
+          }
+          {
+            'match': '(?<=\\d)n\\b|\\b(n|even|odd)\\b'
+            'name': 'constant.other.scss'
+          }
+          {
+            'match': '\\w+'
+            'name': 'invalid.illegal.scss'
+          }
+        ]
+      }
+      {
+        'captures':
+          '1':
+            'name': 'punctuation.definition.entity.css'
+          '2':
+            'name': 'entity.other.attribute-name.pseudo-class.css'
+        'match': '(:)\\b(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid)\\b'
+      }
+    ]
   'selector_pseudo_element':
     'captures':
       '1':

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -155,7 +155,7 @@ describe 'SCSS grammar', ->
       {tokens} = grammar.tokenizeLine 'very-custom:hover { color: red; }'
 
       expect(tokens[0]).toEqual value: 'very-custom', scopes: ['source.css.scss', 'entity.name.tag.custom.scss']
-      expect(tokens[1]).toEqual value: ':', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
+      expect(tokens[1]).toEqual value: ':', scopes: ['source.css.scss', 'punctuation.definition.entity.css']
       expect(tokens[2]).toEqual value: 'hover', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css']
 
     it 'tokenizes them with class selectors', ->
@@ -192,19 +192,59 @@ describe 'SCSS grammar', ->
       expect(tokens[3][4]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss']
       expect(tokens[3][5]).toEqual value: 'none', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.scss']
 
-  describe "pseudo selectors", ->
-    it "parses the value of the argument correctly", ->
-      {tokens} = grammar.tokenizeLine 'div:nth-child(3n+0) { color: red; }'
+  describe 'pseudo classes', ->
+    it 'tokenizes them', ->
+      {tokens} = grammar.tokenizeLine 'a:hover {}'
 
-      expect(tokens[0]).toEqual value: 'div', scopes: ['source.css.scss', 'entity.name.tag.scss']
-      expect(tokens[1]).toEqual value: ':', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
-      expect(tokens[2]).toEqual value: 'nth-child(3n+0)', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css']
+      expect(tokens[1]).toEqual value: ':', scopes: ['source.css.scss', 'punctuation.definition.entity.css']
+      expect(tokens[2]).toEqual value: 'hover', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css']
 
-      {tokens} = grammar.tokenizeLine 'div:nth-child(2n-1) { color: red; }'
+    it 'tokenizes nth-* pseudo classes', ->
+      {tokens} = grammar.tokenizeLine 'a:nth-child(n)'
 
-      expect(tokens[0]).toEqual value: 'div', scopes: ['source.css.scss', 'entity.name.tag.scss']
-      expect(tokens[1]).toEqual value: ':', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
-      expect(tokens[2]).toEqual value: 'nth-child(2n-1)', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css']
+      expect(tokens[2]).toEqual value: 'nth-child', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.begin.bracket.round.css']
+      expect(tokens[4]).toEqual value: 'n', scopes: ['source.css.scss', 'constant.other.scss']
+      expect(tokens[5]).toEqual value: ')', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.end.bracket.round.css']
+
+      {tokens} = grammar.tokenizeLine 'a:nth-child(3n)'
+
+      expect(tokens[2]).toEqual value: 'nth-child', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.begin.bracket.round.css']
+      expect(tokens[4]).toEqual value: '3', scopes: ['source.css.scss', 'constant.numeric.scss']
+      expect(tokens[5]).toEqual value: 'n', scopes: ['source.css.scss', 'constant.other.scss']
+      expect(tokens[6]).toEqual value: ')', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.end.bracket.round.css']
+
+      {tokens} = grammar.tokenizeLine 'a:nth-child(2)'
+
+      expect(tokens[2]).toEqual value: 'nth-child', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.begin.bracket.round.css']
+      expect(tokens[4]).toEqual value: '2', scopes: ['source.css.scss', 'constant.numeric.scss']
+      expect(tokens[5]).toEqual value: ')', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.end.bracket.round.css']
+
+      {tokens} = grammar.tokenizeLine 'a:nth-child(n + 2)'
+
+      expect(tokens[2]).toEqual value: 'nth-child', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.begin.bracket.round.css']
+      expect(tokens[4]).toEqual value: 'n', scopes: ['source.css.scss', 'constant.other.scss']
+      expect(tokens[6]).toEqual value: '2', scopes: ['source.css.scss', 'constant.numeric.scss']
+      expect(tokens[7]).toEqual value: ')', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.end.bracket.round.css']
+
+      {tokens} = grammar.tokenizeLine 'a:nth-child(3n + 2)'
+
+      expect(tokens[2]).toEqual value: 'nth-child', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.begin.bracket.round.css']
+      expect(tokens[4]).toEqual value: '3', scopes: ['source.css.scss', 'constant.numeric.scss']
+      expect(tokens[5]).toEqual value: 'n', scopes: ['source.css.scss', 'constant.other.scss']
+      expect(tokens[7]).toEqual value: '2', scopes: ['source.css.scss', 'constant.numeric.scss']
+      expect(tokens[8]).toEqual value: ')', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.end.bracket.round.css']
+
+      {tokens} = grammar.tokenizeLine 'a:nth-child(hi)'
+
+      expect(tokens[2]).toEqual value: 'nth-child', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.begin.bracket.round.css']
+      expect(tokens[4]).toEqual value: 'hi', scopes: ['source.css.scss', 'invalid.illegal.scss']
+      expect(tokens[5]).toEqual value: ')', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.end.bracket.round.css']
 
   describe "keyframes", ->
     it "parses the from and to properties", ->


### PR DESCRIPTION
Part of the problem is that the first block in [this example](https://github.com/atom/language-sass/issues/70#issuecomment-118499932) is also getting tokenized as a property list.  That hasn't been fixed, but at least it won't affect `nth-child` highlighting now.

Fixes #70