### PR TITLE
Tokenize indented variables in Sass

### DIFF
--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -8,7 +8,7 @@
 'foldingStopMarker': '^\\s*$'
 'patterns': [
   {
-    'begin': '^(\\!|\\$)([a-zA-Z0-9_-]+)\\s*((?:\\|\\|)?=|:)'
+    'begin': '(\\!|\\$)([a-zA-Z0-9_-]+)\\s*((?:\\|\\|)?=|:)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.entity.sass'

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -12,6 +12,25 @@ describe 'SASS grammar', ->
     expect(grammar).toBeTruthy()
     expect(grammar.scopeName).toBe 'source.sass'
 
+  describe 'variables', ->
+    it 'tokenizes them', ->
+      {tokens} = grammar.tokenizeLine '$test: bla'
+
+      expect(tokens[0]).toEqual value: '$', scopes: ['source.sass', 'meta.variable-declaration.sass', 'punctuation.definition.entity.sass']
+      expect(tokens[1]).toEqual value: 'test', scopes: ['source.sass', 'meta.variable-declaration.sass', 'variable.other.sass']
+      expect(tokens[2]).toEqual value: ':', scopes: ['source.sass', 'meta.variable-declaration.sass', 'punctuation.separator.operator.sass']
+      expect(tokens[3]).toEqual value: ' ', scopes: ['source.sass', 'meta.variable-declaration.sass', 'meta.property-value.sass']
+      expect(tokens[4]).toEqual value: 'bla', scopes: ['source.sass', 'meta.variable-declaration.sass', 'meta.property-value.sass']
+
+    it 'tokenizes indented variables', ->
+      {tokens} = grammar.tokenizeLine '  $test: bla'
+
+      expect(tokens[1]).toEqual value: '$', scopes: ['source.sass', 'meta.variable-declaration.sass', 'punctuation.definition.entity.sass']
+      expect(tokens[2]).toEqual value: 'test', scopes: ['source.sass', 'meta.variable-declaration.sass', 'variable.other.sass']
+      expect(tokens[3]).toEqual value: ':', scopes: ['source.sass', 'meta.variable-declaration.sass', 'punctuation.separator.operator.sass']
+      expect(tokens[4]).toEqual value: ' ', scopes: ['source.sass', 'meta.variable-declaration.sass', 'meta.property-value.sass']
+      expect(tokens[5]).toEqual value: 'bla', scopes: ['source.sass', 'meta.variable-declaration.sass', 'meta.property-value.sass']
+
   describe 'comments', ->
     it 'only tokenizes comments that start at the beginning of a line', ->
       {tokens} = grammar.tokenizeLine '  //A comment?'


### PR DESCRIPTION
Because Sass is a whitespace-sensitive language...

Fixes #98