### PR TITLE
Tokenize comments in variables

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1142,6 +1142,12 @@
     'name': 'meta.set.variable.scss'
     'patterns': [
       {
+        'include': '#comment_block'
+      }
+      {
+        'include': '#comment_line'
+      }
+      {
         'include': '#property_values'
       }
       {

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -251,6 +251,15 @@ describe 'SCSS grammar', ->
       expect(tokens[2]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.set.variable.scss']
       expect(tokens[3]).toEqual value: '$normal-font-size', scopes: ['source.css.scss', 'meta.set.variable.scss', 'variable.scss', 'variable.scss']
 
+    it 'tokenizes comments', ->
+      {tokens} = grammar.tokenizeLine '$font-size: // comment'
+
+      expect(tokens[3]).toEqual value: '//', scopes: ['source.css.scss', 'meta.set.variable.scss', 'comment.line.scss', 'punctuation.definition.comment.scss']
+
+      {tokens} = grammar.tokenizeLine '$font-size: /* comment */'
+
+      expect(tokens[3]).toEqual value: '/*', scopes: ['source.css.scss', 'meta.set.variable.scss', 'comment.block.scss', 'punctuation.definition.comment.scss']
+
   describe 'interpolation', ->
     it 'is tokenized within single quotes', ->
       {tokens} = grammar.tokenizeLine "body { font-family: '#\{$family}'; }" # escaping CoffeeScript's interpolation


### PR DESCRIPTION
~~Fixes #102~~

This PR just fixes general comment highlighting in variables.  See #114 for the real fix for maps.