### PR TITLE
Add Sass auto-indentation rules

### DIFF
--- a/settings/language-sass.cson
+++ b/settings/language-sass.cson
@@ -1,7 +1,17 @@
 '.source.sass':
   'editor':
     'autoIndentOnPaste': false
-    'increaseIndentPattern': '^\\s*([^:]+|[}\\w&-]+::?[#\\w&-]+)$'
+    'increaseIndentPattern': '''(?x)
+      ^\\s* # Start of line
+      (
+        [^:]+ # No colons (for regular selectors like body)
+        |
+        [}\\w&-]+::?[#\\w&-]+ # Pseudo-elements/classes (something::before)
+        |
+        @.* # At-rule since some at-rules may contain colons (@media(max-width: 922px))
+      )
+      \\s*$ # End of line
+    '''
 
 '.source.css.scss':
   'editor':

--- a/settings/language-sass.cson
+++ b/settings/language-sass.cson
@@ -1,11 +1,16 @@
 '.source.sass':
   'editor':
     'autoIndentOnPaste': false
+    'increaseIndentPattern': '^\\s*([^:]+|[}\\w&-]+::?[#\\w&-]+)$'
+
+'.source.css.scss':
+  'editor':
+    'increaseIndentPattern': '(^.*\\{[^}]*$)'
+    'decreaseIndentPattern': '^\\s*\\}'
+
 '.source.sass, .source.css.scss':
   'editor':
     'commentStart': '// '
-    'increaseIndentPattern': '(^.*\\{[^}]*$)'
-    'decreaseIndentPattern': '^\\s*\\}'
   'autocomplete':
     'symbols':
       'mixin':


### PR DESCRIPTION
Basically, auto-indent if:
* the line does not contain a colon
OR
* the line is a pseudo-class/element
OR
* the line is an at-rule

This is my first time writing auto-indentation regexes.  Things might not work as expected.

Fixes #95

/cc @johnburkhard, @serhiicss