### PR TITLE
Revert tokenization change for attribute classes

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1016,7 +1016,7 @@
       '1':
         'name': 'punctuation.definition.entity.css'
     'end': '(?![\\w-]|(#{))'
-    'contentName': 'entity.other.attribute-name.class.css'
+    'name': 'entity.other.attribute-name.class.css'
     'patterns': [
       {
         'include': '#interpolation'

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -162,7 +162,7 @@ describe 'SCSS grammar', ->
       {tokens} = grammar.tokenizeLine 'very-custom.class { color: red; }'
 
       expect(tokens[0]).toEqual value: 'very-custom', scopes: ['source.css.scss', 'entity.name.tag.custom.scss']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.css.scss', 'punctuation.definition.entity.css']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'punctuation.definition.entity.css']
       expect(tokens[2]).toEqual value: 'class', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css']
 
     it 'does not confuse them with properties', ->


### PR DESCRIPTION
Preserves compatibility with autocomplete-css.

This is only temporary until I merge the rest of the language-sass PRs that are open.  I took a look at autocomplete-css and have some ideas for improving its scope matching, though that requires changes to other CSS language packages and so is well outside the scope of just updating language-sass.