### PR TITLE
Tokenize `:` as part of a pseudo-class

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1183,17 +1183,17 @@
         ]
       }
       {
-        'captures':
-          '0':
-            'name': 'entity.other.attribute-name.pseudo-class.css'
-          '1':
-            'name': 'punctuation.definition.entity.css'
         'match': '''(?x)
           (:)\\b
           (link|visited|hover|active|focus|target|lang|disabled|enabled|checked|
           indeterminate|root|first-child|last-child|first-of-type|last-of-type|
           only-child|only-of-type|empty|not|valid|invalid)\\b
         '''
+        'captures':
+          '0':
+            'name': 'entity.other.attribute-name.pseudo-class.css'
+          '1':
+            'name': 'punctuation.definition.entity.css'
       }
     ]
   'selector_pseudo_element':

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1155,12 +1155,12 @@
   'selector_pseudo_class':
     'patterns': [
       {
-        'begin': '(:)\\b(nth-(?:child|last-child|of-type|last-of-type))(\\()'
+        'begin': '((:)\\bnth-(?:child|last-child|of-type|last-of-type))(\\()'
         'beginCaptures':
           '1':
-            'name': 'punctuation.definition.entity.css'
-          '2':
             'name': 'entity.other.attribute-name.pseudo-class.css'
+          '2':
+            'name': 'punctuation.definition.entity.css'
           '3':
             'name': 'punctuation.definition.pseudo-class.begin.bracket.round.css'
         'end': '\\)'
@@ -1184,11 +1184,16 @@
       }
       {
         'captures':
+          '0':
+            'name': 'entity.other.attribute-name.pseudo-class.css'
           '1':
             'name': 'punctuation.definition.entity.css'
-          '2':
-            'name': 'entity.other.attribute-name.pseudo-class.css'
-        'match': '(:)\\b(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid)\\b'
+        'match': '''(?x)
+          (:)\\b
+          (link|visited|hover|active|focus|target|lang|disabled|enabled|checked|
+          indeterminate|root|first-child|last-child|first-of-type|last-of-type|
+          only-child|only-of-type|empty|not|valid|invalid)\\b
+        '''
       }
     ]
   'selector_pseudo_element':

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -266,7 +266,7 @@ describe 'SCSS grammar', ->
       {tokens} = grammar.tokenizeLine 'very-custom:hover { color: red; }'
 
       expect(tokens[0]).toEqual value: 'very-custom', scopes: ['source.css.scss', 'entity.name.tag.custom.scss']
-      expect(tokens[1]).toEqual value: ':', scopes: ['source.css.scss', 'punctuation.definition.entity.css']
+      expect(tokens[1]).toEqual value: ':', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
       expect(tokens[2]).toEqual value: 'hover', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css']
 
     it 'tokenizes them with class selectors', ->
@@ -307,7 +307,7 @@ describe 'SCSS grammar', ->
     it 'tokenizes them', ->
       {tokens} = grammar.tokenizeLine 'a:hover {}'
 
-      expect(tokens[1]).toEqual value: ':', scopes: ['source.css.scss', 'punctuation.definition.entity.css']
+      expect(tokens[1]).toEqual value: ':', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
       expect(tokens[2]).toEqual value: 'hover', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css']
 
     it 'tokenizes nth-* pseudo classes', ->


### PR DESCRIPTION
Closes #145