### PR TITLE
Highlighting for scss.liquid

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -5,6 +5,7 @@
   'css.scss'
   'css.scss.erb'
   'scss.erb'
+  'scss.liquid'
 ]
 'patterns': [
   {


### PR DESCRIPTION
Add syntax highlighting for `scss.liquid`. Useful for Shopify theme development, etc.