### PR TITLE
Support CSS variables

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1549,5 +1549,5 @@
       }
     ]
   'variables':
-    'match': '\\$[A-Za-z0-9_-]+\\b'
+    'match': '(\\$|\\-\\-)[A-Za-z0-9_-]+\\b'
     'name': 'variable.scss'

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -665,4 +665,3 @@ describe 'SCSS grammar', ->
       expect(tokens[1][1]).toEqual value: '//', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'comment.line.scss', 'punctuation.definition.comment.scss']
       expect(tokens[2][1]).toEqual value: '/*', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'comment.block.scss', 'punctuation.definition.comment.scss']
       expect(tokens[2][3]).toEqual value: '*/', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'comment.block.scss', 'punctuation.definition.comment.scss']
-

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -496,6 +496,23 @@ describe 'SCSS grammar', ->
       expect(tokens[2]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.set.variable.scss']
       expect(tokens[3]).toEqual value: '$normal-font-size', scopes: ['source.css.scss', 'meta.set.variable.scss', 'variable.scss']
 
+    it "parses css variables", ->
+      {tokens} = grammar.tokenizeLine(".foo { --spacing-unit: 6px; }")
+      expect(tokens).toHaveLength 13
+      expect(tokens[0]).toEqual value: ".", scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'punctuation.definition.entity.css']
+      expect(tokens[1]).toEqual value: "foo", scopes: ['source.css.scss', 'entity.other.attribute-name.class.css']
+      expect(tokens[2]).toEqual value: " ", scopes: ['source.css.scss']
+      expect(tokens[3]).toEqual value: "{", scopes: [ 'source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss' ]
+      expect(tokens[4]).toEqual value: " ", scopes: ['source.css.scss', 'meta.property-list.scss']
+      expect(tokens[5]).toEqual value: "--spacing-unit", scopes: ['source.css.scss', 'meta.property-list.scss', 'variable.scss']
+      expect(tokens[6]).toEqual value: ":", scopes: [ 'source.css.scss', 'meta.property-list.scss', 'punctuation.separator.key-value.scss' ]
+      expect(tokens[7]).toEqual value: " ", scopes: ['source.css.scss', 'meta.property-list.scss']
+      expect(tokens[8]).toEqual value: "6", scopes: [ 'source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss' ]
+      expect(tokens[9]).toEqual value: "px", scopes: [ 'source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'keyword.other.unit.scss' ]
+      expect(tokens[10]).toEqual value: ";", scopes: [ 'source.css.scss', 'meta.property-list.scss', 'punctuation.terminator.rule.scss' ]
+      expect(tokens[11]).toEqual value: " ", scopes: ['source.css.scss', 'meta.property-list.scss']
+      expect(tokens[12]).toEqual value: "}", scopes: [ 'source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.end.bracket.curly.scss' ]
+
     it 'tokenizes maps', ->
       {tokens} = grammar.tokenizeLine '$map: (medium: value, header-height: 10px);'
 
@@ -648,3 +665,4 @@ describe 'SCSS grammar', ->
       expect(tokens[1][1]).toEqual value: '//', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'comment.line.scss', 'punctuation.definition.comment.scss']
       expect(tokens[2][1]).toEqual value: '/*', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'comment.block.scss', 'punctuation.definition.comment.scss']
       expect(tokens[2][3]).toEqual value: '*/', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'comment.block.scss', 'punctuation.definition.comment.scss']
+


### PR DESCRIPTION
### Description of the Change
As for [less](https://github.com/atom/language-less/pull/71), same for scss.

The patch adds support for css variables (properties starting with --) and gives them the same scope as scss variables (`variable.scss`).
```css
:root {
    --spacing-unit: 6px;
    --cell-padding: (4 * var(--spacing-unit));
}
```

Only fixes the issue for SCSS. (I don't know if it is also an issue in SASS)


### Alternate Designs

A different scope could be considered for SCSS , such as `variable.css`, matching the scope that the language-css grammar uses

### Benefits

Correct coloring of css variables in SCSS.