### PR TITLE
Remove unnecessary rgb-specific number matches

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -793,55 +793,6 @@
       \\b
     '''
     'name': 'support.constant.property-value.scss'
-  'constant_rgb':
-    'match': '''(?x)
-                (?<!scale3d\\(|translate3d\\(|rotate3d\\() # scale3d, translate3d, and rotate3d don't use RGB values
-                \\b
-                (0*(?:1?[0-9]{1,2})|(?:2(?:[0-4][0-9]|5[0-5])))
-                \\s*(,)\\s*
-                (0*(?:1?[0-9]{1,2})|(?:2(?:[0-4][0-9]|5[0-5])))
-                \\s*(,)\\s*
-                (0*(?:1?[0-9]{1,2})|(?:2(?:[0-4][0-9]|5[0-5])))
-                \\b
-              '''
-    'captures':
-      '1':
-        'name': 'constant.numeric.color.rgb-value.scss'
-      '2':
-        'name': 'punctuation.separator.delimiter.scss'
-      '3':
-        'name': 'constant.numeric.color.rgb-value.scss'
-      '4':
-        'name': 'punctuation.separator.delimiter.scss'
-      '5':
-        'name': 'constant.numeric.color.rgb-value.scss'
-  'constant_rgb_percentage':
-    'match': '''(?x)
-                (?<!scale3d\\(|translate3d\\(|rotate3d\\() # scale3d, translate3d, and rotate3d don't use RGB percentages
-                \\b
-                ([0-9]{1,2}|100)\\s*(%)
-                \\s*(,)\\s*
-                ([0-9]{1,2}|100)\\s*(%)
-                \\s*(,)\\s*
-                ([0-9]{1,2}|100)\\s*(%)
-              '''
-    'captures':
-      '1':
-        'name': 'constant.numeric.color.rgb-percentage.scss'
-      '2':
-        'name': 'keyword.other.unit.scss'
-      '3':
-        'name': 'punctuation.separator.delimiter.scss'
-      '4':
-        'name': 'constant.numeric.color.rgb-percentage.scss'
-      '5':
-        'name': 'keyword.other.unit.scss'
-      '6':
-        'name': 'punctuation.separator.delimiter.scss'
-      '7':
-        'name': 'constant.numeric.color.rgb-percentage.scss'
-      '8':
-        'name': 'keyword.other.unit.scss'
   'constant_sass_functions':
     'begin': '(headings|stylesheet-url|rgba?|hsla?|ie-hex-str|red|green|blue|alpha|opacity|hue|saturation|lightness|prefixed|prefix|-moz|-svg|-css2|-pie|-webkit|-ms|font-(?:files|url)|grid-image|image-(?:width|height|url|color)|sprites?|sprite-(?:map|map-name|file|url|position)|inline-(?:font-files|image)|opposite-position|grad-point|grad-end-position|color-stops|color-stops-in-percentages|grad-color-stops|(?:radial|linear)-(?:gradient|svg-gradient)|opacify|fade-?in|transparentize|fade-?out|lighten|darken|saturate|desaturate|grayscale|adjust-(?:hue|lightness|saturation|color)|scale-(?:lightness|saturation|color)|change-color|spin|complement|invert|mix|-compass-(?:list|space-list|slice|nth|list-size)|blank|compact|nth|first-value-of|join|length|append|nest|append-selector|headers|enumerate|range|percentage|unitless|unit|if|type-of|comparable|elements-of-type|quote|unquote|escape|e|sin|cos|tan|abs|round|ceil|floor|pi|translate(?:X|Y))(\\()'
     'beginCaptures':
@@ -1239,12 +1190,6 @@
       }
       {
         'include': '#constant_hex'
-      }
-      {
-        'include': '#constant_rgb'
-      }
-      {
-        'include': '#constant_rgb_percentage'
       }
       {
         'include': '#constant_important'

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -470,23 +470,6 @@ describe 'SCSS grammar', ->
       expect(tokens[15]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
       expect(tokens[16]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
 
-    it 'tokenizes RGB values in functions', ->
-      {tokens} = grammar.tokenizeLine '.a { color: rgba(0, 50, 200, 1) }'
-
-      expect(tokens[10]).toEqual value: '0', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.color.rgb-value.scss']
-      expect(tokens[11]).toEqual value: ',', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.separator.delimiter.scss']
-      expect(tokens[12]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss']
-      expect(tokens[13]).toEqual value: '50', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.color.rgb-value.scss']
-      expect(tokens[14]).toEqual value: ',', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.separator.delimiter.scss']
-      expect(tokens[15]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss']
-      expect(tokens[16]).toEqual value: '200', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.color.rgb-value.scss']
-      expect(tokens[17]).toEqual value: ',', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.separator.delimiter.scss']
-      expect(tokens[18]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss']
-      expect(tokens[19]).toEqual value: '1', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss']
-
-      {tokens} = grammar.tokenizeLine '.a { color: translate3d(0, 50, 200) }'
-      expect(tokens[10]).not.toEqual value: '0', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.color.rgb-value.scss']
-
   describe 'variable setting', ->
     it 'parses all tokens', ->
       {tokens} = grammar.tokenizeLine '$font-size: $normal-font-size;'

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -27,6 +27,12 @@ describe 'SCSS grammar', ->
 
       expect(tokens[8]).toEqual value: '.2', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss']
 
+      {tokens} = grammar.tokenizeLine '.something { color: rgba(0, 128, 0, 1) }'
+      expect(tokens[10]).toEqual value: '0', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss']
+      expect(tokens[13]).toEqual value: '128', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss']
+      expect(tokens[16]).toEqual value: '0', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss']
+      expect(tokens[19]).toEqual value: '1', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss']
+
       {tokens} = grammar.tokenizeLine '$q: (color1:$dark-orange);'
 
       expect(tokens[4]).toEqual value: 'color1', scopes: ['source.css.scss', 'meta.set.variable.scss', 'meta.set.variable.map.scss', 'support.type.map.key.scss']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR removes specific regexes that were designed to capture numbers in rgb functions.  The benefit of this is minimal, and the regex is also prone to capturing false positives since it did a negative lookbehind for a specific number of functions that also used three numbers.  Unfortunately, since the number of functions is always growing, this was a rather ineffective measure.

### Alternate Designs

The regex could have been changed to use a _positive_ lookbehind, but I think that the very minimal benefits a custom rgb color capture gives over a more general numeric capture isn't worth maintaining the extra code.

### Benefits

Numbers will be tokenized consistently.

### Possible Drawbacks

Numbers in rgb functions will lose special `rgb-value` tokens.

### Applicable Issues

Fixes #196

/cc @esdoppio