### PR TITLE
Add comment support to media queries

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -431,6 +431,12 @@
         'name': 'meta.at-rule.media.scss'
         'patterns': [
           {
+            'include': '#comment_block'
+          }
+          {
+            'include': '#comment_line'
+          }
+          {
             'match': '\\b(only)\\b'
             'name': 'keyword.control.operator'
           }

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -433,7 +433,7 @@ describe 'SCSS grammar', ->
 
   describe 'media queries', ->
     it 'parses media types and features', ->
-      {tokens} = grammar.tokenizeLine '@media (orientation: landscape) and only screen and (min-width: 700px) {}'
+      {tokens} = grammar.tokenizeLine '@media (orientation: landscape) and only screen and (min-width: 700px) /* comment */ {}'
 
       expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.control.at-rule.media.scss', 'punctuation.definition.keyword.scss']
       expect(tokens[1]).toEqual value: 'media', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.control.at-rule.media.scss']
@@ -446,6 +446,8 @@ describe 'SCSS grammar', ->
       expect(tokens[16]).toEqual value: 'min-width', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'support.type.property-name.media.css']
       expect(tokens[18]).toEqual value: '700', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'constant.numeric.scss']
       expect(tokens[19]).toEqual value: 'px', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.other.unit.scss']
+      expect(tokens[21]).toEqual value: '/*', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'comment.block.scss', 'punctuation.definition.comment.scss']
+      expect(tokens[25]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
 
   describe 'functions', ->
     it 'parses them', ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Simple change to add comments to media queries.

### Alternate Designs

None.

### Benefits

Comments in media queries will be highlighted.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #177