### PR TITLE
Tokenize interpolation and escapes in selectors

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1311,37 +1311,139 @@
       }
     ]
   'selector_attribute':
+    'match': '''(?xi)
+      (\\[)
+      \\s*
+      (
+        (?:
+          [-a-zA-Z_0-9]|[^\\x00-\\x7F]       # Valid identifier characters
+          | \\\\(?:[0-9a-fA-F]{1,6}|.)       # Escape sequence
+          | \\#\\{                           # Interpolation (escaped to avoid Coffeelint errors)
+          | \\$                              # Possible start of interpolation variable
+          | }                                # Possible end of interpolation
+        )+
+      )
+      (?:
+        \\s*([~|^$*]?=)\\s*
+        (?:
+          (
+            (?:
+              [-a-zA-Z_0-9]|[^\\x00-\\x7F]       # Valid identifier characters
+              | \\\\(?:[0-9a-fA-F]{1,6}|.)       # Escape sequence
+              | \\#\\{                           # Interpolation (escaped to avoid Coffeelint errors)
+              | \\$                              # Possible start of interpolation variable
+              | }                                # Possible end of interpolation
+            )+
+          )
+          |
+          (
+            ([\'"])
+            (
+              [^\\\\]|\\\\.
+            )*?
+            (\\6)
+          )
+        )
+      )?
+      \\s*
+      (\\])
+    '''
+    'name': 'meta.attribute-selector.scss'
     'captures':
       '1':
         'name': 'punctuation.definition.attribute-selector.begin.bracket.square.scss'
       '2':
         'name': 'entity.other.attribute-name.attribute.scss'
+        'patterns': [
+          {
+            'include': '#interpolation'
+          }
+          {
+            'match': '\\\\([0-9a-fA-F]{1,6}|.)'
+            'name': 'constant.character.escape.scss'
+          }
+          {
+            # Catch anything that's invalid out of interpolation
+            'match': '\\$|}'
+            'name': 'invalid.illegal.scss'
+          }
+        ]
       '3':
-        'name': 'punctuation.separator.operator.scss'
+        'name': 'keyword.operator.scss'
       '4':
         'name': 'string.unquoted.attribute-value.scss'
+        'patterns': [
+          {
+            'include': '#interpolation'
+          }
+          {
+            'match': '\\\\([0-9a-fA-F]{1,6}|.)'
+            'name': 'constant.character.escape.scss'
+          }
+          {
+            # Catch anything that's invalid out of interpolation
+            'match': '\\$|}'
+            'name': 'invalid.illegal.scss'
+          }
+        ]
       '5':
         'name': 'string.quoted.double.attribute-value.scss'
       '6':
         'name': 'punctuation.definition.string.begin.scss'
       '7':
-        'name': 'punctuation.definition.string.end.scss'
+        'patterns': [
+          {
+            'include': '#interpolation'
+          }
+          {
+            'match': '\\\\([0-9a-fA-F]{1,6}|.)'
+            'name': 'constant.character.escape.scss'
+          }
+          {
+            # Catch anything that's invalid out of interpolation
+            'match': '\\$|}'
+            'name': 'invalid.illegal.scss'
+          }
+        ]
       '8':
+        'name': 'punctuation.definition.string.end.scss'
+      '9':
         'name': 'punctuation.definition.attribute-selector.end.bracket.square.scss'
-    'match': '(?i)(\\[)\\s*(-?[_a-z\\\\[[:^ascii:]]][-_a-z0-9\\\\[[:^ascii:]]]*)(?:\\s*([~|^$*]?=)\\s*(?:(-?[_a-z\\\\[[:^ascii:]]][-_a-z0-9\\\\[[:^ascii:]]]*)|((?>([\'"])(?:[^\\\\]|\\\\.)*?(\\6)))))?\\s*(])'
-    'name': 'meta.attribute-selector.scss'
   'selector_class':
-    'begin': '(\\.)(?=[\\w-]|#{)'
-    'beginCaptures':
+    'match': '''(?x)
+      (\\.)                                  # Valid class-name
+      (
+        (?: [-a-zA-Z_0-9]|[^\\x00-\\x7F]     # Valid identifier characters
+          | \\\\(?:[0-9a-fA-F]{1,6}|.)       # Escape sequence
+          | \\#\\{                           # Interpolation (escaped to avoid Coffeelint errors)
+          | \\$                              # Possible start of interpolation variable
+          | }                                # Possible end of interpolation
+        )+
+      )                                      # Followed by either:
+      (?= $                                  # - End of the line
+        | [\\s,.\\#)\\[:{>+~|]               # - Another selector
+        | /\\*                               # - A block comment
+      )
+    '''
+    'name': 'entity.other.attribute-name.class.css'
+    'captures':
       '1':
         'name': 'punctuation.definition.entity.css'
-    'end': '(?![\\w-]|(#{))'
-    'name': 'entity.other.attribute-name.class.css'
-    'patterns': [
-      {
-        'include': '#interpolation'
-      }
-    ]
+      '2':
+        'patterns': [
+          {
+            'include': '#interpolation'
+          }
+          {
+            'match': '\\\\([0-9a-fA-F]{1,6}|.)'
+            'name': 'constant.character.escape.scss'
+          }
+          {
+            # Catch anything that's invalid out of interpolation
+            'match': '\\$|}'
+            'name': 'invalid.illegal.scss'
+          }
+        ]
   'selector_entities':
     'match': '''(?x)
       \\b
@@ -1374,20 +1476,110 @@
     'match': '\\b([a-zA-Z0-9]+(-[a-zA-Z0-9]+)+)(?=\\.|\\s++[^:]|\\s*[,{]|:(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|nth-(child|last-child|of-type|last-of-type)|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid)(\\([0-9A-Za-z]*\\))?)'
     'name': 'entity.name.tag.custom.scss'
   'selector_id':
+    'match': '''(?x)
+      (\\#)                                  # Valid id-name
+      (
+        (?: [-a-zA-Z_0-9]|[^\\x00-\\x7F]     # Valid identifier characters
+          | \\\\(?:[0-9a-fA-F]{1,6}|.)       # Escape sequence
+          | \\#\\{                           # Interpolation (escaped to avoid Coffeelint errors)
+          | \\$                              # Possible start of interpolation variable
+          | }                                # Possible end of interpolation
+        )+
+      )                                      # Followed by either:
+      (?= $                                  # - End of the line
+        | [\\s,.\\#)\\[:{>+~|]               # - Another selector
+        | /\\*                               # - A block comment
+      )
+    '''
+    'name': 'entity.other.attribute-name.id.css'
     'captures':
       '1':
         'name': 'punctuation.definition.entity.css'
-    'match': '(#)[a-zA-Z][a-zA-Z0-9_-]*'
-    'name': 'entity.other.attribute-name.id.css'
+      '2':
+        'patterns': [
+          {
+            'include': '#interpolation'
+          }
+          {
+            'match': '\\\\([0-9a-fA-F]{1,6}|.)'
+            'name': 'constant.character.escape.scss'
+          }
+          {
+            # Catch anything that's invalid out of interpolation
+            'match': '\\$|}'
+            'name': 'invalid.illegal.identifier.scss'
+          }
+        ]
   'selector_placeholder':
+    'match': '''(?x)
+      (%)                                    # Valid placeholder-name
+      (
+        (?: [-a-zA-Z_0-9]|[^\\x00-\\x7F]     # Valid identifier characters
+          | \\\\(?:[0-9a-fA-F]{1,6}|.)       # Escape sequence
+          | \\#\\{                           # Interpolation (escaped to avoid Coffeelint errors)
+          | \\$                              # Possible start of interpolation variable
+          | }                                # Possible end of interpolation
+        )+
+      )                                      # Followed by either:
+      (?= $                                  # - End of the line
+        | [\\s,.\\#)\\[:{>+~|]               # - Another selector
+        | /\\*                               # - A block comment
+      )
+    '''
+    'name': 'entity.other.attribute-name.placeholder.css'
     'captures':
       '1':
-        'name': 'punctuation.definition.entity.scss'
-    'match': '(%)[a-zA-Z0-9_-]+'
-    'name': 'entity.other.attribute-name.placeholder.scss'
+        'name': 'punctuation.definition.entity.css'
+      '2':
+        'patterns': [
+          {
+            'include': '#interpolation'
+          }
+          {
+            'match': '\\\\([0-9a-fA-F]{1,6}|.)'
+            'name': 'constant.character.escape.scss'
+          }
+          {
+            # Catch anything that's invalid out of interpolation
+            'match': '\\$|}'
+            'name': 'invalid.illegal.identifier.scss'
+          }
+        ]
   'parent_selector_suffix':
-    'match': '(?<=&)[a-zA-Z0-9_-]+'
-    'name': 'entity.other.attribute-name.parent-selector-suffix.scss'
+    'match': '''(?x)
+      (?<=&)
+      (
+        (?: [-a-zA-Z_0-9]|[^\\x00-\\x7F]     # Valid identifier characters
+          | \\\\(?:[0-9a-fA-F]{1,6}|.)       # Escape sequence
+          | \\#\\{                           # Interpolation (escaped to avoid Coffeelint errors)
+          | \\$                              # Possible start of interpolation variable
+          | }                                # Possible end of interpolation
+        )+
+      )                                      # Followed by either:
+      (?= $                                  # - End of the line
+        | [\\s,.\\#)\\[:{>+~|]               # - Another selector
+        | /\\*                               # - A block comment
+      )
+    '''
+    'name': 'entity.other.attribute-name.parent-selector-suffix.css'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.entity.css'
+      '2':
+        'patterns': [
+          {
+            'include': '#interpolation'
+          }
+          {
+            'match': '\\\\([0-9a-fA-F]{1,6}|.)'
+            'name': 'constant.character.escape.scss'
+          }
+          {
+            # Catch anything that's invalid out of interpolation
+            'match': '\\$|}'
+            'name': 'invalid.illegal.identifier.scss'
+          }
+        ]
   'selector_pseudo_class':
     'patterns': [
       {
@@ -1404,6 +1596,9 @@
           '0':
             'name': 'punctuation.definition.pseudo-class.end.bracket.round.css'
         'patterns': [
+          {
+            'include': '#interpolation'
+          }
           {
             'match': '\\d+'
             'name': 'constant.numeric.scss'

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1336,13 +1336,9 @@
             )+
           )
           |
-          (
-            ([\'"])
-            (
-              [^\\\\]|\\\\.
-            )*?
-            (\\6)
-          )
+          ((")(.*)("))
+          |
+          ((')(.*)('))
         )
       )?
       \\s*
@@ -1408,6 +1404,27 @@
       '8':
         'name': 'punctuation.definition.string.end.scss'
       '9':
+        'name': 'string.quoted.single.attribute-value.scss'
+      '10':
+        'name': 'punctuation.definition.string.begin.scss'
+      '11':
+        'patterns': [
+          {
+            'include': '#interpolation'
+          }
+          {
+            'match': '\\\\([0-9a-fA-F]{1,6}|.)'
+            'name': 'constant.character.escape.scss'
+          }
+          {
+            # Catch anything that's invalid out of interpolation
+            'match': '\\$|}'
+            'name': 'invalid.illegal.scss'
+          }
+        ]
+      '12':
+        'name': 'punctuation.definition.string.end.scss'
+      '13':
         'name': 'punctuation.definition.attribute-selector.end.bracket.square.scss'
   'selector_class':
     'match': '''(?x)
@@ -1473,7 +1490,7 @@
     '''
     'name': 'entity.name.tag.scss'
   'selector_custom':
-    'match': '\\b([a-zA-Z0-9]+(-[a-zA-Z0-9]+)+)(?=\\.|\\s++[^:]|\\s*[,{]|:(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|nth-(child|last-child|of-type|last-of-type)|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid)(\\([0-9A-Za-z]*\\))?)'
+    'match': '\\b([a-zA-Z0-9]+(-[a-zA-Z0-9]+)+)(?=\\.|\\s++[^:]|\\s*[,\\[{]|:(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|nth-(child|last-child|of-type|last-of-type)|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid)(\\([0-9A-Za-z]*\\))?)'
     'name': 'entity.name.tag.custom.scss'
   'selector_id':
     'match': '''(?x)

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -41,6 +41,82 @@ describe 'SCSS grammar', ->
 
       expect(tokens[11]).toEqual value: '-', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'keyword.operator.css']
 
+  describe 'selectors', ->
+    # TODO: We need more coverage of selectors
+    selectors =
+      'class': '.'
+      'id': '#'
+      'parent': '&'
+      'placeholder': '%'
+
+    for scope, selector of selectors
+      it "tokenizes complex #{scope} selectors", ->
+        {tokens} = grammar.tokenizeLine "#{selector}legit-#\{$selector}-name\\@sm"
+
+        expect(tokens[0]).toEqual value: selector, scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "punctuation.definition.entity.css"]
+        expect(tokens[1]).toEqual value: "legit-", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+        expect(tokens[2]).toEqual value: "#\{", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
+        expect(tokens[3]).toEqual value: "$selector", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "variable.scss"]
+        expect(tokens[4]).toEqual value: "}", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
+        expect(tokens[5]).toEqual value: "-name", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+        expect(tokens[6]).toEqual value: "\\@", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "constant.character.escape.scss"]
+        expect(tokens[7]).toEqual value: "sm", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+
+      it "tokenizes invalid identifiers in #{scope} selectors", ->
+        {tokens} = grammar.tokenizeLine "#{selector}legit-#\{$selector}-n}a$me\\@sm"
+
+        expect(tokens[0]).toEqual value: selector, scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "punctuation.definition.entity.css"]
+        expect(tokens[1]).toEqual value: "legit-", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+        expect(tokens[2]).toEqual value: "#\{", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
+        expect(tokens[3]).toEqual value: "$selector", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "variable.scss"]
+        expect(tokens[4]).toEqual value: "}", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
+        expect(tokens[5]).toEqual value: "-n", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+        expect(tokens[6]).toEqual value: "}", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "invalid.illegal.identifier.scss"]
+        expect(tokens[7]).toEqual value: "a", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+        expect(tokens[8]).toEqual value: "$", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "invalid.illegal.identifier.scss"]
+        expect(tokens[9]).toEqual value: "me", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+        expect(tokens[10]).toEqual value: "\\@", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "constant.character.escape.scss"]
+        expect(tokens[11]).toEqual value: "sm", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+
+    it "tokenizes complex pseudo-selectors", ->
+      {tokens} = grammar.tokenizeLine "&:nth-child(#\{$j})"
+
+      expect(tokens[0]).toEqual value: "&", scopes: ["source.css.scss", "entity.name.tag.reference.scss"]
+      expect(tokens[1]).toEqual value: ":", scopes: ["source.css.scss", "entity.other.attribute-name.pseudo-class.css", "punctuation.definition.entity.css"]
+      expect(tokens[2]).toEqual value: "nth-child", scopes: ["source.css.scss", "entity.other.attribute-name.pseudo-class.css"]
+      expect(tokens[3]).toEqual value: "(", scopes: ["source.css.scss", "punctuation.definition.pseudo-class.begin.bracket.round.css"]
+      expect(tokens[4]).toEqual value: "#\{", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
+      expect(tokens[5]).toEqual value: "$j", scopes: ["source.css.scss", "variable.interpolation.scss", "variable.scss"]
+      expect(tokens[6]).toEqual value: "}", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
+      expect(tokens[7]).toEqual value: ")", scopes: ["source.css.scss", "punctuation.definition.pseudo-class.end.bracket.round.css"]
+
+  describe "attribute selectors", ->
+    it "tokenizes them correctly", ->
+      {tokens} = grammar.tokenizeLine '[something="1"]'
+
+      expect(tokens[0]).toEqual value: '[', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'punctuation.definition.attribute-selector.begin.bracket.square.scss']
+      expect(tokens[1]).toEqual value: 'something', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'entity.other.attribute-name.attribute.scss']
+      expect(tokens[2]).toEqual value: '=', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'keyword.operator.scss']
+      expect(tokens[3]).toEqual value: '"', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'string.quoted.double.attribute-value.scss', 'punctuation.definition.string.begin.scss']
+      expect(tokens[5]).toEqual value: '"', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'string.quoted.double.attribute-value.scss', 'punctuation.definition.string.end.scss']
+      expect(tokens[6]).toEqual value: ']', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'punctuation.definition.attribute-selector.end.bracket.square.scss']
+
+    it "tokenizes complex attribute selectors", ->
+      {tokens} = grammar.tokenizeLine "[cla#\{$s}^=abc#\{d}e]"
+
+      expect(tokens[0]).toEqual value: "[", scopes: ["source.css.scss", "meta.attribute-selector.scss", "punctuation.definition.attribute-selector.begin.bracket.square.scss"]
+      expect(tokens[1]).toEqual value: "cla", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss"]
+      expect(tokens[2]).toEqual value: "#\{", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
+      expect(tokens[3]).toEqual value: "$s", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss", "variable.interpolation.scss", "variable.scss"]
+      expect(tokens[4]).toEqual value: "}", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
+      expect(tokens[5]).toEqual value: "^=", scopes: ["source.css.scss", "meta.attribute-selector.scss", "keyword.operator.scss"]
+      expect(tokens[6]).toEqual value: "abc", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.unquoted.attribute-value.scss"]
+      expect(tokens[7]).toEqual value: "#\{", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.unquoted.attribute-value.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
+      expect(tokens[8]).toEqual value: "d", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.unquoted.attribute-value.scss", "variable.interpolation.scss"]
+      expect(tokens[9]).toEqual value: "}", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.unquoted.attribute-value.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
+      expect(tokens[10]).toEqual value: "e", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.unquoted.attribute-value.scss"]
+      expect(tokens[11]).toEqual value: "]", scopes: ["source.css.scss", "meta.attribute-selector.scss", "punctuation.definition.attribute-selector.end.bracket.square.scss"]
+
   describe '@at-root', ->
     it 'tokenizes it correctly', ->
       {tokens} = grammar.tokenizeLine '@at-root (without: media) .btn { color: red; }'
@@ -380,17 +456,6 @@ describe 'SCSS grammar', ->
       expect(tokens[3]).toEqual value: '(', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.begin.bracket.round.css']
       expect(tokens[4]).toEqual value: 'hi', scopes: ['source.css.scss', 'invalid.illegal.scss']
       expect(tokens[5]).toEqual value: ')', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.end.bracket.round.css']
-
-  describe 'attribute selectors', ->
-    it 'parses them correctly', ->
-      {tokens} = grammar.tokenizeLine '[something="1"]'
-
-      expect(tokens[0]).toEqual value: '[', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'punctuation.definition.attribute-selector.begin.bracket.square.scss']
-      expect(tokens[1]).toEqual value: 'something', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'entity.other.attribute-name.attribute.scss']
-      expect(tokens[2]).toEqual value: '=', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'punctuation.separator.operator.scss']
-      expect(tokens[3]).toEqual value: '"', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'string.quoted.double.attribute-value.scss', 'punctuation.definition.string.begin.scss']
-      expect(tokens[5]).toEqual value: '"', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'string.quoted.double.attribute-value.scss', 'punctuation.definition.string.end.scss']
-      expect(tokens[6]).toEqual value: ']', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'punctuation.definition.attribute-selector.end.bracket.square.scss']
 
   describe '@keyframes', ->
     it 'parses the from and to properties', ->

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -78,18 +78,6 @@ describe 'SCSS grammar', ->
         expect(tokens[10]).toEqual value: "\\@", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "constant.character.escape.scss"]
         expect(tokens[11]).toEqual value: "sm", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
 
-    it "tokenizes complex pseudo-selectors", ->
-      {tokens} = grammar.tokenizeLine "&:nth-child(#\{$j})"
-
-      expect(tokens[0]).toEqual value: "&", scopes: ["source.css.scss", "entity.name.tag.reference.scss"]
-      expect(tokens[1]).toEqual value: ":", scopes: ["source.css.scss", "entity.other.attribute-name.pseudo-class.css", "punctuation.definition.entity.css"]
-      expect(tokens[2]).toEqual value: "nth-child", scopes: ["source.css.scss", "entity.other.attribute-name.pseudo-class.css"]
-      expect(tokens[3]).toEqual value: "(", scopes: ["source.css.scss", "punctuation.definition.pseudo-class.begin.bracket.round.css"]
-      expect(tokens[4]).toEqual value: "#\{", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
-      expect(tokens[5]).toEqual value: "$j", scopes: ["source.css.scss", "variable.interpolation.scss", "variable.scss"]
-      expect(tokens[6]).toEqual value: "}", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
-      expect(tokens[7]).toEqual value: ")", scopes: ["source.css.scss", "punctuation.definition.pseudo-class.end.bracket.round.css"]
-
   describe "attribute selectors", ->
     it "tokenizes them correctly", ->
       {tokens} = grammar.tokenizeLine '[something="1"]'
@@ -98,6 +86,7 @@ describe 'SCSS grammar', ->
       expect(tokens[1]).toEqual value: 'something', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'entity.other.attribute-name.attribute.scss']
       expect(tokens[2]).toEqual value: '=', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'keyword.operator.scss']
       expect(tokens[3]).toEqual value: '"', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'string.quoted.double.attribute-value.scss', 'punctuation.definition.string.begin.scss']
+      expect(tokens[4]).toEqual value: '1', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'string.quoted.double.attribute-value.scss']
       expect(tokens[5]).toEqual value: '"', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'string.quoted.double.attribute-value.scss', 'punctuation.definition.string.end.scss']
       expect(tokens[6]).toEqual value: ']', scopes: ['source.css.scss', 'meta.attribute-selector.scss', 'punctuation.definition.attribute-selector.end.bracket.square.scss']
 
@@ -376,6 +365,18 @@ describe 'SCSS grammar', ->
       expect(tokens[1]).toEqual value: '.', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'punctuation.definition.entity.css']
       expect(tokens[2]).toEqual value: 'class', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css']
 
+    it "tokenizes them with attribute selectors", ->
+      {tokens} = grammar.tokenizeLine "md-toolbar[color='primary']"
+
+      expect(tokens[0]).toEqual value: "md-toolbar", scopes: ["source.css.scss", "entity.name.tag.custom.scss"]
+      expect(tokens[1]).toEqual value: "[", scopes: ["source.css.scss", "meta.attribute-selector.scss", "punctuation.definition.attribute-selector.begin.bracket.square.scss"]
+      expect(tokens[2]).toEqual value: "color", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss"]
+      expect(tokens[3]).toEqual value: "=", scopes: ["source.css.scss", "meta.attribute-selector.scss", "keyword.operator.scss"]
+      expect(tokens[4]).toEqual value: "'", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.quoted.single.attribute-value.scss", "punctuation.definition.string.begin.scss"]
+      expect(tokens[5]).toEqual value: "primary", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.quoted.single.attribute-value.scss"]
+      expect(tokens[6]).toEqual value: "'", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.quoted.single.attribute-value.scss", "punctuation.definition.string.end.scss"]
+      expect(tokens[7]).toEqual value: ']', scopes: ["source.css.scss", "meta.attribute-selector.scss", "punctuation.definition.attribute-selector.end.bracket.square.scss"]
+
     it 'does not confuse them with properties', ->
       tokens = grammar.tokenizeLines '''
         body {
@@ -456,6 +457,18 @@ describe 'SCSS grammar', ->
       expect(tokens[3]).toEqual value: '(', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.begin.bracket.round.css']
       expect(tokens[4]).toEqual value: 'hi', scopes: ['source.css.scss', 'invalid.illegal.scss']
       expect(tokens[5]).toEqual value: ')', scopes: ['source.css.scss', 'punctuation.definition.pseudo-class.end.bracket.round.css']
+
+    it "tokenizes complex pseudo classes", ->
+      {tokens} = grammar.tokenizeLine "&:nth-child(#\{$j})"
+
+      expect(tokens[0]).toEqual value: "&", scopes: ["source.css.scss", "entity.name.tag.reference.scss"]
+      expect(tokens[1]).toEqual value: ":", scopes: ["source.css.scss", "entity.other.attribute-name.pseudo-class.css", "punctuation.definition.entity.css"]
+      expect(tokens[2]).toEqual value: "nth-child", scopes: ["source.css.scss", "entity.other.attribute-name.pseudo-class.css"]
+      expect(tokens[3]).toEqual value: "(", scopes: ["source.css.scss", "punctuation.definition.pseudo-class.begin.bracket.round.css"]
+      expect(tokens[4]).toEqual value: "#\{", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
+      expect(tokens[5]).toEqual value: "$j", scopes: ["source.css.scss", "variable.interpolation.scss", "variable.scss"]
+      expect(tokens[6]).toEqual value: "}", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
+      expect(tokens[7]).toEqual value: ")", scopes: ["source.css.scss", "punctuation.definition.pseudo-class.end.bracket.round.css"]
 
   describe '@keyframes', ->
     it 'parses the from and to properties', ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Tokenize interpolation and escapes in selectors, update a scope to use `keyword` instead of `punctuation.separator`, and allow attribute selectors to follow a custom element.

### Alternate Designs

None.

### Benefits

More complex selectors should receive correct highlighting instead of having "invalid" tokens everywhere.

### Possible Drawbacks

This is a somewhat large PR, but I still don't anticipate any drawbacks.  There is a large gap in spec coverage of selectors, however.

### Applicable Issues

Fixes #187
Fixes #189
Fixes #193