### PR TITLE
Allow parentheses in property values

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -441,10 +441,50 @@
             'name': 'keyword.control.operator'
           }
           {
-            'include': '#media_features'
-          }
-          {
-            'include': '#property_values'
+            'begin': '\\('
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.media-query.begin.bracket.round.scss'
+            'end': '\\)'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.definition.media-query.end.bracket.round.scss'
+            'name': 'meta.property-list.media-query.scss'
+            'patterns': [
+              {
+                'begin': '(?<![-a-z])(?=[-a-z])'
+                'end': '$|(?![-a-z])'
+                'name': 'meta.property-name.media-query.scss'
+                'patterns': [
+                  {
+                    'include': '#media_features'
+                  }
+                  {
+                    'include': '#property_names'
+                  }
+                ]
+              }
+              {
+                'begin': '(:)\\s*(?!(\\s*{))'
+                'beginCaptures':
+                  '1':
+                    'name': 'punctuation.separator.key-value.scss'
+                'comment': 'Kuroir: fixed nested elements for sass.'
+                'end': '\\s*(;|(?=}|\\)))'
+                'endCaptures':
+                  '1':
+                    'name': 'punctuation.terminator.rule.scss'
+                'contentName': 'meta.property-value.media-query.scss'
+                'patterns': [
+                  {
+                    'include': '#general'
+                  }
+                  {
+                    'include': '#property_values'
+                  }
+                ]
+              }
+            ]
           }
           {
             'include': '#variable'
@@ -454,9 +494,6 @@
           }
           {
             'include': '#media_types'
-          }
-          {
-            'include': '#property_names'
           }
         ]
       }
@@ -1009,34 +1046,13 @@
         'name': 'punctuation.separator.delimiter.scss'
       }
       {
+        'include': '#map'
+      }
+      {
         'include': '#property_values'
       }
       {
         'include': '#variable'
-      }
-      {
-        'include': '#map'
-      }
-    ]
-  'media_attributes':
-    'patterns': [
-      {
-        'match': ':'
-        'name': 'punctuation.separator.key-value.scss'
-      }
-      {
-        'include': '#general'
-      }
-      {
-        'include': '#property_name'
-      }
-      {
-        'include': '#property_values'
-      }
-      {
-        'comment': 'We even have error highlighting <3'
-        'match': '[={}\\?@]'
-        'name': 'invalid.illegal.scss'
       }
     ]
   'media_features':
@@ -1062,12 +1078,6 @@
         'include': '#variable'
       }
       {
-        'include': '#property_values'
-      }
-      {
-        'include': '#comment_block'
-      }
-      {
         'begin': '\\('
         'beginCaptures':
           '0':
@@ -1081,6 +1091,12 @@
             'include': '#function_attributes'
           }
         ]
+      }
+      {
+        'include': '#property_values'
+      }
+      {
+        'include': '#comment_block'
       }
       {
         'match': '[^\'",) \\t]+'
@@ -1287,6 +1303,24 @@
       }
       {
         'include': '#operators'
+      }
+      {
+        'begin': '\\('
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.begin.bracket.round.scss'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.end.bracket.round.scss'
+        'patterns': [
+          {
+            'include': '#general'
+          }
+          {
+            'include': '#property_values'
+          }
+        ]
       }
     ]
   'rules':

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -241,6 +241,26 @@ describe 'SCSS grammar', ->
       expect(tokens[1][0]).toEqual value: 'another-one', scopes: ['source.css.scss', 'entity.name.tag.custom.scss']
       expect(tokens[1][10]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.end.bracket.curly.scss']
 
+    describe 'property values', ->
+      it 'tokenizes parentheses', ->
+        {tokens} = grammar.tokenizeLine '.foo { margin: ($bar * .8) 0 ($bar * .8) ($bar * 2);'
+        expect(tokens[8]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.begin.bracket.round.scss']
+        expect(tokens[9]).toEqual value: '$bar', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
+        expect(tokens[11]).toEqual value: '*', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'keyword.operator.css']
+        expect(tokens[13]).toEqual value: '.8', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss']
+        expect(tokens[14]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
+        expect(tokens[16]).toEqual value: '0', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss']
+        expect(tokens[18]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.begin.bracket.round.scss']
+        expect(tokens[19]).toEqual value: '$bar', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
+        expect(tokens[21]).toEqual value: '*', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'keyword.operator.css']
+        expect(tokens[23]).toEqual value: '.8', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss']
+        expect(tokens[24]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
+        expect(tokens[26]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.begin.bracket.round.scss']
+        expect(tokens[27]).toEqual value: '$bar', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
+        expect(tokens[29]).toEqual value: '*', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'keyword.operator.css']
+        expect(tokens[31]).toEqual value: '2', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss']
+        expect(tokens[32]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
+
   describe 'property names with a prefix that matches an element name', ->
     it 'does not confuse them with properties', ->
       tokens = grammar.tokenizeLines '''
@@ -437,17 +457,26 @@ describe 'SCSS grammar', ->
 
       expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.control.at-rule.media.scss', 'punctuation.definition.keyword.scss']
       expect(tokens[1]).toEqual value: 'media', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.control.at-rule.media.scss']
-      expect(tokens[4]).toEqual value: 'orientation', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'support.type.property-name.media.css']
-      expect(tokens[6]).toEqual value: 'landscape', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'support.constant.property-value.scss']
-      expect(tokens[8]).toEqual value: 'and', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.operator.logical.scss']
-      expect(tokens[10]).toEqual value: 'only', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.control.operator']
-      expect(tokens[12]).toEqual value: 'screen', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'support.constant.media.css']
-      expect(tokens[14]).toEqual value: 'and', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.operator.logical.scss']
-      expect(tokens[16]).toEqual value: 'min-width', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'support.type.property-name.media.css']
-      expect(tokens[18]).toEqual value: '700', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'constant.numeric.scss']
-      expect(tokens[19]).toEqual value: 'px', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.other.unit.scss']
-      expect(tokens[21]).toEqual value: '/*', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'comment.block.scss', 'punctuation.definition.comment.scss']
-      expect(tokens[25]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
+      expect(tokens[2]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.at-rule.media.scss']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.definition.media-query.begin.bracket.round.scss']
+      expect(tokens[4]).toEqual value: 'orientation', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'meta.property-name.media-query.scss', 'support.type.property-name.media.css']
+      expect(tokens[5]).toEqual value: ':', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.separator.key-value.scss']
+      expect(tokens[6]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss']
+      expect(tokens[7]).toEqual value: 'landscape', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'meta.property-value.media-query.scss', 'support.constant.property-value.scss']
+      expect(tokens[8]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.definition.media-query.end.bracket.round.scss']
+      expect(tokens[9]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.at-rule.media.scss']
+      expect(tokens[10]).toEqual value: 'and', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.operator.logical.scss']
+      expect(tokens[12]).toEqual value: 'only', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.control.operator']
+      expect(tokens[14]).toEqual value: 'screen', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'support.constant.media.css']
+      expect(tokens[16]).toEqual value: 'and', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.operator.logical.scss']
+      expect(tokens[18]).toEqual value: '(', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.definition.media-query.begin.bracket.round.scss']
+      expect(tokens[19]).toEqual value: 'min-width', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'meta.property-name.media-query.scss', 'support.type.property-name.media.css']
+      expect(tokens[20]).toEqual value: ':', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.separator.key-value.scss']
+      expect(tokens[22]).toEqual value: '700', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'meta.property-value.media-query.scss', 'constant.numeric.scss']
+      expect(tokens[23]).toEqual value: 'px', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'meta.property-value.media-query.scss', 'keyword.other.unit.scss']
+      expect(tokens[24]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.definition.media-query.end.bracket.round.scss']
+      expect(tokens[26]).toEqual value: '/*', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'comment.block.scss', 'punctuation.definition.comment.scss']
+      expect(tokens[30]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
 
   describe 'functions', ->
     it 'parses them', ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Tokenize parentheses in property values, and as a side effect move around some of the includes so that they work properly.
Also, add property-list tokens to media queries.

### Alternate Designs

None.

### Benefits

See above.

### Possible Drawbacks

I don't think there will be any.

### Applicable Issues

Fixes #194