### PR TITLE
Source keyword lists from CSS grammar

### DIFF
--- a/.coffeelintignore
+++ b/.coffeelintignore
@@ -1,1 +1,0 @@
-spec/fixtures

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -244,7 +244,7 @@
     ]
   }
   {
-    'comment': 'Place for improvements after sass.cson refactor'
+    # Place for improvements after sass.cson refactor
     'begin': '^\\s*((@)at-root)(?!(?:\\s+[^.\\(])|(?:\\s+\\((?!with)))'
     'beginCaptures':
       '1':

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -315,38 +315,14 @@
         'name': 'keyword.other.parent-reference.sass'
       }
       {
-        'match': '''(?x)
-          \\b
-          (a|abbr|acronym|address|area|article|aside|audio|
-          b|base|bdi|bdo|big|blockquote|body|br|button|
-          canvas|caption|circle|cite|code|col|colgroup|
-          data|datalist|dd|del|details|dfn|dialog|div|dl|dt|
-          ellipse|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|
-          g|
-          (h[1-6])|head|header|hgroup|hr|html|
-          i|iframe|img|image|input|ins|
-          kbd|keygen|
-          label|legend|li|line|link|
-          main|map|mark|menu|menuitem|meta|meter|
-          nav|noframes|noscript|
-          object|ol|optgroup|option|output|
-          p|param|path|picture|polygon|polyline|pre|progress|
-          q|
-          rb|rect|rp|rt|rtc|ruby|
-          s|samp|script|section|select|small|source|span|strike|strong|style|sub|summary|sup|svg|
-          table|tbody|td|template|text|textarea|textpath|tfoot|th|thead|time|title|tr|track|tspan|tt|
-          u|ul|
-          var|video|
-          wbr)\\b
-        '''
-        'name': 'entity.name.tag.css.sass'
-      }
-      {
         'captures':
           '1':
             'name': 'punctuation.definition.entity.css'
         'match': '(\\.)[a-zA-Z0-9_-]+'
         'name': 'entity.other.attribute-name.class.sass'
+      }
+      {
+        'include': 'source.css#tag-names'
       }
       {
         'captures':
@@ -360,18 +336,10 @@
         'name': 'entity.name.tag.wildcard.sass'
       }
       {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.entity.sass'
-        'match': '(:+)\\b(after|before|first-child|first-letter|first-line|last-child|nth-child|placeholder|selection)\\b'
-        'name': 'entity.other.attribute-name.pseudo-element.sass'
+        'include': 'source.css#pseudo-elements'
       }
       {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.entity.sass'
-        'match': '(:)\\b(active|hover|link|visited|focus)\\b'
-        'name': 'entity.other.attribute-name.pseudo-class.css.sass'
+        'include': 'source.css#pseudo-classes'
       }
       {
         'captures':
@@ -395,6 +363,24 @@
       {
         'match': '(?<=&)[a-zA-Z0-9_-]+'
         'name': 'entity.other.attribute-name.parent-selector-suffix.css.sass'
+      }
+      {
+        'match': '(?<!$)([a-zA-Z0-9_-]+)\\s*(:)(.*)$'
+        'captures':
+          '1':
+            'patterns': [
+              {
+                'include': 'source.css#property-names'
+              }
+            ]
+          '2':
+            'name': 'punctuation.separator.operator.sass'
+          '3':
+            'patterns': [
+              {
+                'include': '#property-value'
+              }
+            ]
       }
     ]
   }
@@ -494,34 +480,7 @@
     'name': 'meta.property-name.sass'
     'patterns': [
       {
-        'match': '''(?x)
-          (-(?:webkit|moz|ms)-[-a-z]+|
-          z-index|
-          word-wrap|word-spacing|word-break|will-change|width|widows|white-space|weight|
-          volume|voice-volume|voice-stress|voice-rate|voice-range|voice-pitch|voice-family|voice-duration|voice-balance|visibility|vertical-align|
-          user-select|unicode-bidi|
-          transition-timing-function|transition-property|transition-duration|transition-delay|transition|transform|touch-action|top|text-wrap|text-transform|text-shadow|text-justify|text-indent|text-emphasis|text-decoration|text-align-last|text-align|text|table-layout|tab-size|
-          style|stroke|string-set|stress|src|speech-rate|speak-punctuation|speak-numeral|speak-header|speak|size|shape-outside|shadow|
-          ruby-position|ruby-align|rotation-point|rotation|right|richness|rest-before|rest-after|rest|resize|repeat|
-          quotes|
-          presentation-level|position|pointer-events|play-during|pitch-range|pitch|perspective|pause-before|pause-after|pause|page-break-inside|page-break-before|page-break-after|page|padding-top|padding-right|padding-left|padding-bottom|padding|
-          overflow-y|overflow-x|overflow-wrap|overflow-style|overflow|outline-width|outline-style|outline-offset|outline-color|outline|orphans|order|opacity|object-position|object-fit|
-          nav-up|nav-right|nav-left|nav-down|
-          min-width|min-height|max-width|max-height|marquee-style|marquee-speed|marquee-direction|marks|marker-offset|marker|margin-top|margin-right|margin-left|margin-bottom|margin|
-          list-style-type|list-style-position|list-style-image|list-style|line-height|letter-spacing|left|
-          justify-content|
-          indent|image-resolution|image-orientation|image|
-          hyphens|hyphenate-character|height|hanging-punctuation|
-          grid|
-          font-weight|font-variant|font-style|font-stretch|font-size-adjust|font-size|font-family|font|float|flex-wrap|flex-shrink|flex-grow|flex-flow|flex-direction|flex-basis|flex|filter|family|
-          empty-cells|elevation|
-          dominant-baseline|display|direction|decoration|
-          cursor|cue-before|cue-after|cue|counter-reset|counter-increment|content|columns|column-width|column-span|column-rule-width|column-rule-style|column-rule-color|column-rule|column-gap|column-fill|column-count|color|clip|clear|caption-side|break-inside|
-          break-before|break-after|box-sizing|box-shadow|box-decoration-break|bottom-color|bottom|border-width|border-top-width|border-top-style|border-top-right-radius|border-top-left-radius|border-top-color|border-top|border-style|border-spacing|border-right-width|border-right-style|border-right-color|border-right|border-radius|border-left-width|border-left-style|border-left-color|border-left|border-image|border-color|border-collapse|border-bottom-width|border-bottom-style|border-bottom-right-radius|border-bottom-left-radius|border-bottom-color|border-bottom|border|bookmark-level|bookmark-label|baseline-shift|background-size|background-repeat|background-position-y|background-position-x|background-position|background-origin|background-image|background-color|background-clip|background-attachment|background|backface-visibility|
-          azimuth|appearance|animation-timing-function|animation-play-state|animation-name|animation-iteration-count|animation-fill-mode|animation-duration|animation-direction|animation-delay|animation|alignment-baseline|align-self|align-items|align-content|align)
-          \\b
-        '''
-        'name': 'support.type.property-name.css.sass'
+        'include': 'source.css#property-names'
       }
       {
         'include': '#property-value'
@@ -530,34 +489,18 @@
   }
   {
     'begin': '''(?x)
-      ^[\\s\\t]+(-(?:webkit|moz|ms)-[-a-z]+|
-      z-index|
-      word-wrap|word-spacing|word-break|will-change|width|widows|white-space|weight|
-      volume|voice-volume|voice-stress|voice-rate|voice-range|voice-pitch|voice-family|voice-duration|voice-balance|visibility|vertical-align|
-      user-select|unicode-bidi|
-      transition-timing-function|transition-property|transition-duration|transition-delay|transition|transform|touch-action|top|text-wrap|text-transform|text-shadow|text-justify|text-indent|text-emphasis|text-decoration|text-align-last|text-align|text|table-layout|tab-size|
-      style|stroke|string-set|stress|src|speech-rate|speak-punctuation|speak-numeral|speak-header|speak|size|shape-outside|shadow|
-      ruby-position|ruby-align|rotation-point|rotation|right|richness|rest-before|rest-after|rest|resize|repeat|
-      quotes|
-      presentation-level|position|pointer-events|play-during|pitch-range|pitch|perspective|pause-before|pause-after|pause|page-break-inside|page-break-before|page-break-after|page|padding-top|padding-right|padding-left|padding-bottom|padding|
-      overflow-y|overflow-x|overflow-wrap|overflow-style|overflow|outline-width|outline-style|outline-offset|outline-color|outline|orphans|order|opacity|object-position|object-fit|
-      nav-up|nav-right|nav-left|nav-down|
-      min-width|min-height|max-width|max-height|marquee-style|marquee-speed|marquee-direction|marks|marker-offset|marker|margin-top|margin-right|margin-left|margin-bottom|margin|
-      list-style-type|list-style-position|list-style-image|list-style|line-height|letter-spacing|left|
-      justify-content|
-      indent|image-resolution|image-orientation|image|
-      hyphens|hyphenate-character|height|hanging-punctuation|
-      grid|
-      font-weight|font-variant|font-style|font-stretch|font-size-adjust|font-size|font-family|font|float|flex-wrap|flex-shrink|flex-grow|flex-flow|flex-direction|flex-basis|flex|filter|family|
-      empty-cells|elevation|
-      dominant-baseline|display|direction|decoration|
-      cursor|cue-before|cue-after|cue|counter-reset|counter-increment|content|columns|column-width|column-span|column-rule-width|column-rule-style|column-rule-color|column-rule|column-gap|column-fill|column-count|color|clip|clear|caption-side|
-      break-inside|break-before|break-after|box-sizing|box-shadow|box-decoration-break|bottom-color|bottom|border-width|border-top-width|border-top-style|border-top-right-radius|border-top-left-radius|border-top-color|border-top|border-style|border-spacing|border-right-width|border-right-style|border-right-color|border-right|border-radius|border-left-width|border-left-style|border-left-color|border-left|border-image|border-color|border-collapse|border-bottom-width|border-bottom-style|border-bottom-right-radius|border-bottom-left-radius|border-bottom-color|border-bottom|border|bookmark-level|bookmark-label|baseline-shift|background-size|background-repeat|background-position-y|background-position-x|background-position|background-origin|background-image|background-color|background-clip|background-attachment|background|backface-visibility|
-      azimuth|appearance|animation-timing-function|animation-play-state|animation-name|animation-iteration-count|animation-fill-mode|animation-duration|animation-direction|animation-delay|animation|alignment-baseline|align-self|align-items|align-content|align)\\b([\\s\\t]*:|\\s?=)
+      ^
+      \\s+
+      ([-A-Za-z]+)
+      (\\s*:|\\s?=)
     '''
     'beginCaptures':
       '1':
-        'name': 'support.type.property-name.css.sass'
+        'patterns': [
+          {
+            'include': 'source.css#property-names'
+          }
+        ]
       '2':
         'name': 'punctuation.definition.entity.css.sass'
     'end': '(;)?$'
@@ -634,74 +577,14 @@
         'name': 'meta.variable-usage.sass'
       }
       {
-        'match': '''(?x)
-          \\b
-          (absolute|all-scroll|always|auto|
-          baseline|below|bidi-override|block|bold|bolder|border-box|both|bottom|break-all|break-word|butt|
-          capitalize|center|char|circle|col-resize|collapse|contain|content-box|cover|crosshair|
-          dashed|decimal|default|disabled|disc|distribute-all-lines|distribute-letter|distribute-space|distribute|dotted|double|
-          e-resize|ease-in-out|ease-in|ease-out|ease|ellipsis|
-          false|fill|fixed|
-          grid|groove|
-          hand|help|hidden|horizontal|
-          ideograph-alpha|ideograph-numeric|ideograph-parenthesis|ideograph-space|inactive|inherit|inline-block|inline-flex|inline-grid|inline-table|inline|inset|inside|inter-ideograph|inter-word|italic|
-          justify|
-          keep-all|
-          left|lighter|line-edge|line-through|linear|line|list-item|loose|lower-alpha|lower-roman|lowercase|lr-tb|ltr|
-          manipulation|margin-box|medium|middle|move|
-          n-resize|ne-resize|newspaper|no-drop|no-repeat|nw-resize|none|normal|not-allowed|nowrap|
-          oblique|outset|outside|overline|
-          padding-box|pan-(x|y|left|right|up|down)|pointer|pre-wrap|pre-line|pre|preserve-3d|progress|
-          relative|repeat-x|repeat-y|repeat|right|ridge|round|row-resize|rtl|ruby-base-container|ruby-base|ruby-text-container|ruby-text|ruby|
-          s-resize|scale-down|scroll|se-resize|separate|small-caps|solid|square|static|step-end|step-start|strict|super|sw-resize|
-          table-caption|table-cell|table-column-group|table-column|table-footer-group|table-header-group|table-row-group|table-row|table|tb-rl|text-bottom|text-top|text|thick|thin|top|transparent|true|
-          underline|upper-alpha|upper-roman|uppercase|
-          vertical-ideographic|vertical-text|visible|
-          w-resize|wait|whitespace)
-          \\b
-        '''
+        'match': '\\b(true|false)\\b'
         'name': 'support.constant.property-value.css.sass'
       }
       {
-        'match': '(\\b(?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida(?: sans)?|symbol|system|tahoma|times(?: new roman)?|trebuchet|utopia|verdana|webdings|sans-serif|serif|mono|monospace)\\b)'
-        'name': 'support.constant.font-name.css.sass'
+        'include': 'source.css#property-keywords'
       }
       {
-        'match': '(\\b((?:x{1,2}-)?small|smaller|medium|(?:x{1,2}-)?large|larger)\\b)'
-        'name': 'support.constant.font-size.css.sass'
-      }
-      {
-        'comment': 'http://www.w3.org/TR/css3-color/#svg-color'
-        'match': '''(?x)
-          \\b
-          (aliceblue|antiquewhite|aqua|aquamarine|azure|
-          beige|bisque|black|blanchedalmond|blue|blueviolet|brown|burlywood|
-          cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|cyan|
-          darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|
-          firebrick|floralwhite|forestgreen|fuchsia|
-          gainsboro|ghostwhite|gold|goldenrod|gray|green|greenyellow|grey|
-          honeydew|hotpink|
-          indianred|indigo|ivory|
-          khaki|
-          lavender|lavenderblush|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|lime|limegreen|linen|
-          magenta|maroon|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|
-          navajowhite|navy|
-          oldlace|olive|olivedrab|orange|orangered|orchid|
-          palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|purple|
-          red|rosybrown|royalblue|
-          saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|silver|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|
-          tan|teal|thistle|tomato|turquoise|
-          violet|
-          wheat|white|whitesmoke|
-          yellow|yellowgreen)
-          \\b
-        '''
-        'name': 'support.constant.color.w3c-standard-color-name.css.sass'
-      }
-      {
-        'comment': 'These colours are deprecated from CSS color module level 3 http://www.w3.org/TR/css3-color/#css2-system'
-        'match': '\\b(ActiveBorder|ActiveCaption|AppWorkspace|Background|ButtonFace|ButtonHighlight|ButtonShadow|ButtonText|CaptionText|GrayText|Highlight|HighlightText|InactiveBorder|InactiveCaption|InactiveCaptionText|InfoBackground|InfoText|Menu|MenuText|Scrollbar|ThreeDDarkShadow|ThreeDFace|ThreeDHighlight|ThreeDLightShadow|ThreeDShadow|Window|WindowFrame|WindowText)\\b'
-        'name': 'invalid.deprecated.color.system.css.sass'
+        'include': 'source.css#color-keywords'
       }
       {
         'captures':

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -63,9 +63,9 @@
     'include': '#at_rule_supports'
   }
 ]
+# Note how all @rules are prefixed by "at_rule__".
 'repository':
-  'at_rule__':
-    'comment': 'Note how all @rules are prefixed.'
+  # Charset
   'at_rule_charset':
     'begin': '\\s*((@)charset\\b)\\s*'
     'captures':
@@ -73,7 +73,6 @@
         'name': 'keyword.control.at-rule.charset.scss'
       '2':
         'name': 'punctuation.definition.keyword.scss'
-    'comment': 'Charset'
     'end': '\\s*((?=;|$))'
     'name': 'meta.at-rule.charset.scss'
     'patterns': [
@@ -214,6 +213,7 @@
   'at_rule_function':
     'patterns': [
       {
+        # Function with attributes
         'begin': '\\s*((@)function\\b)\\s*'
         'captures':
           '1':
@@ -222,7 +222,6 @@
             'name': 'punctuation.definition.keyword.scss'
           '3':
             'name': 'entity.name.function.scss'
-        'comment': 'Function with Attributes'
         'end': '\\s*(?={)'
         'name': 'meta.at-rule.function.scss'
         'patterns': [
@@ -232,6 +231,7 @@
         ]
       }
       {
+        # Simple function
         'captures':
           '1':
             'name': 'keyword.control.at-rule.function.scss'
@@ -239,7 +239,6 @@
             'name': 'punctuation.definition.keyword.scss'
           '3':
             'name': 'entity.name.function.scss'
-        'comment': 'Simple Function'
         'match': '\\s*((@)function\\b)\\s*'
         'name': 'meta.at-rule.function.scss'
       }
@@ -465,11 +464,11 @@
                 ]
               }
               {
+                # Kuroir: fixed nested elements for sass.
                 'begin': '(:)\\s*(?!(\\s*{))'
                 'beginCaptures':
                   '1':
                     'name': 'punctuation.separator.key-value.scss'
-                'comment': 'Kuroir: fixed nested elements for sass.'
                 'end': '\\s*(;|(?=}|\\)))'
                 'endCaptures':
                   '1':
@@ -589,18 +588,19 @@
         'name': 'meta.at-rule.namespace.scss'
       }
     ]
+  # Option
   'at_rule_option':
     'captures':
       '1':
         'name': 'keyword.control.at-rule.charset.scss'
       '2':
         'name': 'punctuation.definition.keyword.scss'
-    'comment': 'Option'
     'match': '^\\s*((@)option\\b)\\s*'
     'name': 'meta.at-rule.option.scss'
   'at_rule_page':
     'patterns': [
       {
+        # Page with attributes
         'begin': '^\\s*((@)page)(?=:|\\s)\\s*([-:\\w]*)'
         'captures':
           '1':
@@ -609,7 +609,6 @@
             'name': 'punctuation.definition.keyword.scss'
           '3':
             'name': 'entity.name.function.scss'
-        'comment': 'Page with Attributes'
         'end': '\\s*(?={)'
         'name': 'meta.at-rule.page.scss'
       }
@@ -829,7 +828,7 @@
         'include': '#property_values'
       }
       {
-        'comment': 'We even have error highlighting <3'
+        # We even have error highlighting <3
         'match': '[={}\\?;@]'
         'name': 'invalid.illegal.scss'
       }
@@ -858,8 +857,8 @@
         'name': 'support.function.misc.scss'
       }
     ]
+  # Stuff that should be everywhere
   'general':
-    'comment': 'Stuff that should be everywhere'
     'patterns': [
       {
         'include': '#variable'
@@ -997,11 +996,11 @@
         ]
       }
       {
+        # Kuroir: fixed nested elements for sass.
         'begin': '(:)\\s*(?!(\\s*{))'
         'beginCaptures':
           '1':
             'name': 'punctuation.separator.key-value.scss'
-        'comment': 'Kuroir: fixed nested elements for sass.'
         'end': '\\s*(;|(?=}|\\)))'
         'endCaptures':
           '1':
@@ -1041,8 +1040,8 @@
         'include': '$self'
       }
     ]
+  # Stuff that should only be available on values.
   'property_values':
-    'comment': 'Stuff that should only be available on values.'
     'patterns': [
       {
         'include': '#string_single'
@@ -1425,8 +1424,8 @@
         'include': 'source.css#pseudo-classes'
       }
     ]
+  # Stuff for selectors
   'selectors':
-    'comment': 'Stuff for Selectors.'
     'patterns': [
       {
         'include': 'source.css#tag-names'

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -457,10 +457,10 @@
                 'name': 'meta.property-name.media-query.scss'
                 'patterns': [
                   {
-                    'include': '#media_features'
+                    'include': 'source.css#media-features'
                   }
                   {
-                    'include': '#property_names'
+                    'include': 'source.css#property-names'
                   }
                 ]
               }
@@ -493,7 +493,7 @@
             'include': '#conditional_operators'
           }
           {
-            'include': '#media_types'
+            'include': 'source.css#media-types'
           }
         ]
       }
@@ -736,43 +736,9 @@
         'name': 'punctuation.definition.comment.scss'
     'end': '\\n'
     'name': 'comment.line.scss'
-  'constant_color':
-    'comment': 'http://www.w3.org/TR/css3-color/#svg-color'
-    'match': '''(?x)
-      \\b
-      (aliceblue|antiquewhite|aqua|aquamarine|azure|
-      beige|bisque|black|blanchedalmond|blue|blueviolet|brown|burlywood|
-      cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|cyan|
-      darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|
-      firebrick|floralwhite|forestgreen|fuchsia|
-      gainsboro|ghostwhite|gold|goldenrod|gray|green|greenyellow|grey|
-      honeydew|hotpink|
-      indianred|indigo|ivory|
-      khaki|
-      lavender|lavenderblush|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|lime|limegreen|linen|
-      magenta|maroon|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|
-      navajowhite|navy|
-      oldlace|olive|olivedrab|orange|orangered|orchid|
-      palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|purple|
-      red|rosybrown|royalblue|
-      saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|silver|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|
-      tan|teal|thistle|tomato|turquoise|
-      violet|
-      wheat|white|whitesmoke|
-      yellow|yellowgreen)
-      \\b
-    '''
-    'name': 'support.constant.color.w3c-standard-color-name.scss'
   'constant_default':
     'match': '!default'
     'name': 'keyword.other.default.scss'
-  'constant_deprecated_color':
-    'comment': 'These colours are deprecated from CSS color module level 3 http://www.w3.org/TR/css3-color/#css2-system'
-    'match': '\\b(ActiveBorder|ActiveCaption|AppWorkspace|Background|ButtonFace|ButtonHighlight|ButtonShadow|ButtonText|CaptionText|GrayText|Highlight|HighlightText|InactiveBorder|InactiveCaption|InactiveCaptionText|InfoBackground|InfoText|Menu|MenuText|Scrollbar|ThreeDDarkShadow|ThreeDFace|ThreeDHighlight|ThreeDLightShadow|ThreeDShadow|Window|WindowFrame|WindowText)\\b'
-    'name': 'invalid.deprecated.color.system.css.scss'
-  'constant_font':
-    'match': '(\\b(?i:arial|century|comic|courier|garamond|georgia|helvetica|impact|lucida|symbol|system|tahoma|times|trebuchet|utopia|verdana|webdings|sans-serif|serif|monospace)\\b)'
-    'name': 'support.constant.font-name.scss'
   'constant_functions':
     'begin': '([\\w-]+)(\\()'
     'beginCaptures':
@@ -807,35 +773,6 @@
   'constant_optional':
     'match': '!optional'
     'name': 'keyword.other.optional.scss'
-  'constant_property_value':
-    'match': '''(?x)
-      \\b
-      (absolute|all-scroll|always|armenian|auto|
-      baseline|below|bidi-override|block|bold|bolder|both|bottom|border-box|break-all|break-word|butt|
-      capitalize|center|char|circle|cjk-ideographic|col-resize|collapse|column-reverse|column|contain|content-box|cover|crosshair|currentColor|
-      dashed|decimal-leading-zero|decimal|default|disabled|disc|distribute-all-lines|distribute-letter|distribute-space|distribute|dotted|double|
-      e-resize|ease-in-out|ease-in|ease-out|ease|ellipsis|
-      fill|fixed|flex-end|flex-start|flex|
-      georgian|grid|groove|
-      hand|hebrew|help|hidden|hiragana-iroha|hiragana|horizontal|
-      ideograph-alpha|ideograph-numeric|ideograph-parenthesis|ideograph-space|inactive|inherit|inline-block|inline-flex|inline-grid|inline-table|inline|inset|inside|inter-ideograph|inter-word|italic|
-      justify|
-      katakana-iroha|katakana|keep-all|
-      landscape|left|lighter|line-edge|line-through|line|linear|list-item|loose|lower-alpha|lower-greek|lower-latin|lower-roman|lowercase|lr-tb|ltr|
-      manipulation|margin-box|medium|middle|move|
-      n-resize|ne-resize|newspaper|no-drop|no-repeat|nw-resize|none|normal|not-allowed|nowrap|null|
-      oblique|outset|outside|overline|
-      padding-box|pan-(x|y|left|right|up|down)|pointer|portrait|preserve-3d|progress|
-      relative|repeat-x|repeat-y|repeat|right|ridge|round|row-resize|row-reverse|row|rtl|ruby-base-container|ruby-base|ruby-text-container|ruby-text|ruby|
-      s-resize|scale-down|scroll|se-resize|separate|small-caps|solid|space-around|space-between|square|static|step-end|step-start|stretch|strict|super|sw-resize|
-      table-caption|table-cell|table-column-group|table-column|table-footer-group|table-header-group|table-row-group|table-row|table|tb-rl|text-bottom|text-top|text|thick|thin|top|transparent|
-      underline|upper-alpha|upper-latin|upper-roman|uppercase|
-      vertical-ideographic|vertical-text|visible|
-      w-resize|wait|whitespace|wrap|wrap-reverse|
-      zero|true|false|vertical|horizontal)
-      \\b
-    '''
-    'name': 'support.constant.property-value.scss'
   'constant_sass_functions':
     'begin': '(headings|stylesheet-url|rgba?|hsla?|ie-hex-str|red|green|blue|alpha|opacity|hue|saturation|lightness|prefixed|prefix|-moz|-svg|-css2|-pie|-webkit|-ms|font-(?:files|url)|grid-image|image-(?:width|height|url|color)|sprites?|sprite-(?:map|map-name|file|url|position)|inline-(?:font-files|image)|opposite-position|grad-point|grad-end-position|color-stops|color-stops-in-percentages|grad-color-stops|(?:radial|linear)-(?:gradient|svg-gradient)|opacify|fade-?in|transparentize|fade-?out|lighten|darken|saturate|desaturate|grayscale|adjust-(?:hue|lightness|saturation|color)|scale-(?:lightness|saturation|color)|change-color|spin|complement|invert|mix|-compass-(?:list|space-list|slice|nth|list-size)|blank|compact|nth|first-value-of|join|length|append|nest|append-selector|headers|enumerate|range|percentage|unitless|unit|if|type-of|comparable|elements-of-type|quote|unquote|escape|e|sin|cos|tan|abs|round|ceil|floor|pi|translate(?:X|Y))(\\()'
     'beginCaptures':
@@ -1006,20 +943,6 @@
         'include': '#variable'
       }
     ]
-  'media_features':
-    'patterns': [
-      {
-        'match': '\\b(min-device-aspect-ratio|max-device-aspect-ratio|device-aspect-ratio|min-aspect-ratio|max-aspect-ratio|aspect-ratio|min-device-height|max-device-height|device-height|min-device-width|max-device-width|device-width|min-monochrome|max-monochrome|monochrome|min-color-index|max-color-index|color-index|min-color|max-color|color|orientation|scan|min-resolution|max-resolution|resolution|grid|min-width|max-width|width)\\b'
-        'name': 'support.type.property-name.media.css'
-      }
-    ]
-  'media_types':
-    'patterns': [
-      {
-        'match': '\\b(all|aural|braille|embossed|handheld|print|projection|screen|tty|tv)\\b'
-        'name': 'support.constant.media.css'
-      }
-    ]
   'operators':
     'match': '[-+*/](?!\\s*[-+*/])'
     'name': 'keyword.operator.css'
@@ -1066,7 +989,7 @@
         'name': 'meta.property-name.scss'
         'patterns': [
           {
-            'include': '#property_names'
+            'include': 'source.css#property-names'
           }
           {
             'include': '#at_rule_include'
@@ -1118,83 +1041,6 @@
         'include': '$self'
       }
     ]
-  'property_name':
-    'comment': 'Reversal order is important; KEEP IT. Also when adding new properties add them to the error checker below!'
-    'match': '''(?x)
-      ((?<=\\s|^)(-webkit-[A-Za-z-]+|-moz-[A-Za-z-]+|-ms-[A-Za-z-]+))|
-      \\b
-      ([0-9]{1,3}%|
-      zoom|z-index|
-      y|
-      x|
-      wrap|word-wrap|word-spacing|word-break|word|width|widows|will-change|white-space-collapse|white-space|white|weight|
-      volume|voice-volume|voice-stress|voice-rate|voice-pitch-range|voice-pitch|voice-family|voice-duration|voice-balance|voice|visibility|vertical-align|variant|
-      user-select|up|unicode-bidi|unicode|
-      trim|transition-timing-function|transition-property|transition-duration|transition-delay|transition|transform|touch-action|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|text-wrap|text-transform|text-shadow|text-replace|text-outline|text-justify|text-indent|text-height|text-emphasis|text-decoration|text-align-last|text-align|text|target-position|target-new|target-name|target|table-layout|tab-size|
-      style-type|style-position|style-image|style|stroke|string-set|stretch|stress|stacking-strategy|stacking-shift|stacking-ruby|stacking|src|speed|speech-rate|speech|speak-punctuation|speak-numeral|speak-header|speak|span|spacing|space-collapse|space|sizing|size-adjust|size|shape-outside|shadow|
-      respond-to|rule-width|rule-style|rule-color|rule|ruby-span|ruby-position|ruby-overhang|ruby-align|ruby|rows|rotation-point|rotation|role|right-width|right-style|right-color|right|richness|rest-before|rest-after|rest|resource|resolution|resize|reset|replace|repeat|rendering-intent|rate|radius|
-      quotes|
-      punctuation-trim|punctuation|property|profile|presentation-level|presentation|position|pointer-events|point|play-state|play-during|play-count|pitch-range|pitch|phonemes|perspective|pause-before|pause-after|pause|page-policy|page-break-inside|page-break-before|page-break-after|page|padding-top|padding-right|padding-left|padding-bottom|padding|pack|
-      overhang|overflow-y|overflow-x|overflow-wrap|overflow-style|overflow|outline-width|outline-style|outline-offset|outline-color|outline|orphans|origin|orientation|orient|ordinal-group|order|opacity|offset|object-position|object-fit|
-      numeral|new|nav-up|nav-right|nav-left|nav-index|nav-down|nav|name|
-      move-to|model|min-width|min-height|min|max-width|max-height|max|marquee-style|marquee-speed|marquee-play-count|marquee-direction|marquee|marks|mark-before|mark-after|marker|mark|margin-top|margin-right|margin-left|margin-bottom|margin|mask-image|
-      list-style-type|list-style-position|list-style-image|list-style|list|lines|line-stacking-strategy|line-stacking-shift|line-stacking-ruby|line-stacking|line-height|line|level|letter-spacing|length|left-width|left-style|left-color|left|label|
-      justify-content|justify|
-      iteration-count|inline-box-align|initial-value|initial-size|initial-before-align|initial-before-adjust|initial-after-align|initial-after-adjust|index|indent|increment|image-resolution|image-orientation|image|icon|
-      hyphens|hyphenate-resource|hyphenate-lines|hyphenate-character|hyphenate-before|hyphenate-after|hyphenate|height|header|hanging-punctuation|
-      grid-rows|grid-columns|grid|gap|
-      font-weight|font-variant|font-variant-ligatures|font-style|font-stretch|font-size-adjust|font-size|font-family|font|float-offset|float|flex-wrap|flex-shrink|flex-grow|flex-group|flex-flow|flex-direction|flex-basis|flex|fit-position|fit|fill|filter|family|
-      empty-cells|emphasis|elevation|
-      duration|drop-initial-value|drop-initial-size|drop-initial-before-align|drop-initial-before-adjust|drop-initial-after-align|drop-initial-after-adjust|drop|down|dominant-baseline|display-role|display-model|display|direction|delay|decoration-break|decoration|
-      cursor|cue-before|cue-after|cue|crop|counter-reset|counter-increment|counter|count|content|columns|column-width|column-span|column-rule-width|column-rule-style|column-rule-color|column-rule|column-gap|column-fill|column-count|column-break-before|column-break-after|column|color-profile|color|collapse|clip|clear|character|caption-side|
-      break-inside|break-before|break-after|break|box-sizing|box-shadow|box-pack|box-orient|box-ordinal-group|box-lines|box-flex-group|box-flex|box-direction|box-decoration-break|box-align|box|bottom-width|bottom-style|bottom-right-radius|bottom-left-radius|bottom-color|bottom|border-width|border-top-width|border-top-style|border-top-right-radius|border-top-left-radius|border-top-color|border-top|border-style|border-spacing|border-right-width|border-right-style|border-right-color|border-right|border-radius|border-length|border-left-width|border-left-style|border-left-color|border-left|border-image|border-color|border-collapse|border-bottom-width|border-bottom-style|border-bottom-right-radius|border-bottom-left-radius|border-bottom-color|border-bottom|border|bookmark-target|bookmark-level|bookmark-label|bookmark|binding|bidi|before|baseline-shift|baseline|balance|background-size|background-repeat|background-position-y|background-position-x|background-position|background-origin|background-image|background-color|background-clip|background-break|background-attachment|background|backface-visibility|
-      azimuth|attachment|appearance|animation-timing-function|animation-play-state|animation-name|animation-iteration-count|animation-fill-mode|animation-duration|animation-direction|animation-delay|animation|alignment-baseline|alignment-adjust|alignment|align-self|align-last|align-items|align-content|align|after|adjust)
-      \\b
-    '''
-    'name': 'support.type.property-name.scss'
-  'property_name_error':
-    'match': '''(?x)
-      (?<![a-z-])
-      (?!-(top|right|left|bottom|color|radius|last|inside|width|before|after|value|size|type|position|style|image|strategy|shift|align|adjust)\\b|
-      -webkit-[A-Za-z]+\\b|
-      -moz-[A-Za-z]+\\b|
-      -ms-[A-Za-z]+\\b|
-      z-index\\b|[0-9]{1,3}%\\b|zoom\\b|
-      y\\b|
-      x\\b|
-      wrap\\b|word-wrap\\b|word-spacing\\b|word-break\\b|word\\b|will-change\\b|width\\b|widows\\b|white-space-collapse\\b|white-space\\b|white\\b|weight\\b|
-      volume\\b|voice-volume\\b|voice-stress\\b|voice-rate\\b|voice-pitch-range\\b|voice-pitch\\b|voice-family\\b|voice-duration\\b|voice-balance\\b|voice\\b|visibility\\b|vertical-align\\b|variant\\b|
-      user-select\\b|up\\b|unicode-bidi\\b|unicode\\b|u\\b|
-      tt\\b|trim\\b|transition-timing-function\\b|transition-property\\b|transition-duration\\b|transition-delay\\b|transition\\b|transform\\b|touch-action\\b|top-width\\b|top-style\\b|top-right-radius\\b|top-left-radius\\b|top-color\\b|top\\b|timing-function\\b|text-wrap\\b|text-transform\\b|text-shadow\\b|text-replace\\b|text-outline\\b|text-justify\\b|text-indent\\b|text-height\\b|text-emphasis\\b|text-decoration\\b|text-align-last\\b|text-align\\b|text\\b|target-position\\b|target-new\\b|target-name\\b|target\\b|table-layout\\b|tab-size\\b|
-      style-type\\b|style-position\\b|style-image\\b|style\\b|string-set\\b|stroke\\b|strike\\b|stretch\\b|stress\\b|stacking-strategy\\b|stacking-shift\\b|stacking-ruby\\b|stacking\\b|src\\b|speed\\b|speech-rate\\b|speech\\b|speak-punctuation\\b|speak-numeral\\b|speak-header\\b|speak\\b|span\\b|spacing\\b|space-collapse\\b|space\\b|sizing\\b|size-adjust\\b|size\\b|shape-outside\\b|shadow\\b|s\\b|
-      respond-to\\b|rule-width\\b|rule-style\\b|rule-color\\b|rule\\b|ruby-span\\b|ruby-position\\b|ruby-overhang\\b|ruby-align\\b|ruby\\b|rows\\b|rotation-point\\b|rotation\\b|role\\b|right-width\\b|right-style\\b|right-color\\b|right\\b|richness\\b|rest-before\\b|rest-after\\b|rest\\b|resource\\b|resolution\\b|resize\\b|reset\\b|replace\\b|repeat\\b|rendering-intent\\b|rate\\b|radius\\b|
-      quotes\\b|
-      punctuation-trim\\b|punctuation\\b|property\\b|profile\\b|presentation-level\\b|presentation\\b|position\\b|pointer-events\\b|point\\b|play-state\\b|play-during\\b|play-count\\b|pitch-range\\b|pitch\\b|phonemes\\b|pause-before\\b|pause-after\\b|pause\\b|page-policy\\b|page-break-inside\\b|page-break-before\\b|page-break-after\\b|page\\b|padding-top\\b|padding-right\\b|padding-left\\b|padding-bottom\\b|padding\\b|pack\\b|
-      overhang\\b|overflow-y\\b|overflow-x\\b|overflow-wrap\\b|overflow-style\\b|overflow\\b|outline-width\\b|outline-style\\b|outline-offset\\b|outline-color\\b|outline\\b|orphans\\b|origin\\b|orientation\\b|orient\\b|ordinal-group\\b|order\\b|opacity\\b|offset\\b|object-position\\b|object-fit\\b|
-      numeral\\b|new\\b|nav-up\\b|nav-right\\b|nav-left\\b|nav-index\\b|nav-down\\b|nav\\b|name\\b|
-      move-to\\b|model\\b|min-width\\b|min-height\\b|min\\b|max-width\\b|max-height\\b|max\\b|marquee-style\\b|marquee-speed\\b|marquee-play-count\\b|marquee-direction\\b|marquee\\b|marks\\b|mark-before\\b|mark-after\\b|marker\\b|mark\\b|margin-top\\b|margin-right\\b|margin-left\\b|margin-bottom\\b|margin\\b|mask-image\\b|
-      list-style-type\\b|list-style-position\\b|list-style-image\\b|list-style\\b|list\\b|lines\\b|line-stacking-strategy\\b|line-stacking-shift\\b|line-stacking-ruby\\b|line-stacking\\b|line-height\\b|line\\b|level\\b|letter-spacing\\b|length\\b|left-width\\b|left-style\\b|left-color\\b|left\\b|label\\b|
-      justify-content\\b|justify\\b|
-      iteration-count\\b|inline-box-align\\b|initial-value\\b|initial-size\\b|initial-before-align\\b|initial-before-adjust\\b|initial-after-align\\b|initial-after-adjust\\b|index\\b|indent\\b|increment\\b|image-resolution\\b|image-orientation\\b|image\\b|icon\\b|
-      hyphens\\b|hyphenate-resource\\b|hyphenate-lines\\b|hyphenate-character\\b|hyphenate-before\\b|hyphenate-after\\b|hyphenate\\b|height\\b|header\\b|hanging-punctuation\\b|
-      grid-rows\\b|grid-columns\\b|grid\\b|gap\\b|
-      font-weight\\b|font-variant\\b|font-variant-ligatures\\b|font-style\\b|font-stretch\\b|font-size-adjust\\b|font-size\\b|font-family\\b|font\\b|float-offset\\b|float\\b|flex-wrap\\b|flex-shrink\\b|flex-grow\\b|flex-group\\b|flex-flow\\b|flex-direction\\b|flex-basis\\b|flex\\b|fit-position\\b|fit\\b|fill\\b|filter\\b|family\\b|
-      empty-cells\\b|emphasis\\b|elevation\\b|
-      duration\\b|drop-initial-value\\b|drop-initial-size\\b|drop-initial-before-align\\b|drop-initial-before-adjust\\b|drop-initial-after-align\\b|drop-initial-after-adjust\\b|drop\\b|down\\b|dominant-baseline\\b|display-role\\b|display-model\\b|display\\b|direction\\b|delay\\b|decoration-break\\b|decoration\\b|
-      cursor\\b|cue-before\\b|cue-after\\b|cue\\b|crop\\b|counter-reset\\b|counter-increment\\b|counter\\b|count\\b|content\\b|columns\\b|column-width\\b|column-span\\b|column-rule-width\\b|column-rule-style\\b|column-rule-color\\b|column-rule\\b|column-gap\\b|column-fill\\b|column-count\\b|column-break-before\\b|column-break-after\\b|column\\b|color-profile\\b|color\\b|collapse\\b|clip\\b|clear\\b|character\\b|center\\b|caption-side\\b|
-      break-inside\\b|break-before\\b|break-after\\b|break\\b|box-sizing\\b|box-shadow\\b|box-pack\\b|box-orient\\b|box-ordinal-group\\b|box-lines\\b|box-flex-group\\b|box-flex\\b|box-direction\\b|box-decoration-break\\b|box-align\\b|box\\b|bottom-width\\b|bottom-style\\b|bottom-right-radius\\b|bottom-left-radius\\b|bottom-color\\b|bottom\\b|border-width\\b|border-top-width\\b|border-top-style\\b|border-top-right-radius\\b|border-top-left-radius\\b|border-top-color\\b|border-top\\b|border-style\\b|border-spacing\\b|border-right-width\\b|border-right-style\\b|border-right-color\\b|border-right\\b|border-radius\\b|border-length\\b|border-left-width\\b|border-left-style\\b|border-left-color\\b|border-left\\b|border-image\\b|border-color\\b|border-collapse\\b|border-bottom-width\\b|border-bottom-style\\b|border-bottom-right-radius\\b|border-bottom-left-radius\\b|border-bottom-color\\b|border-bottom\\b|border\\b|bookmark-target\\b|bookmark-level\\b|bookmark-label\\b|bookmark\\b|binding\\b|bidi\\b|big\\b|before\\b|baseline-shift\\b|baseline\\b|balance\\b|background-size\\b|background-repeat\\b|background-position-y\\b|background-position-x\\b|background-position\\b|background-origin\\b|background-image\\b|background-color\\b|background-clip\\b|background-break\\b|background-attachment\\b|background\\b|backface-visibility\\b|
-      azimuth\\b|attachment\\b|applet\\b|appearance\\b|animation-timing-function\\b|animation-play-state\\b|animation-name\\b|animation-iteration-count\\b|animation-fill-mode\\b|animation-duration\\b|animation-direction\\b|animation-delay\\b|animation\\b|alignment-baseline\\b|alignment-adjust\\b|alignment\\b|align-last\\b|align-self\\b|align-items\\b|align-content\\b|align\\b|after\\b|adjust\\b|acronym\\b)[-_a-z]+
-    '''
-    'name': 'invalid.illegal.scss'
-  'property_names':
-    'patterns': [
-      {
-        'include': '#property_name'
-      }
-      {
-        'include': '#property_name_error'
-      }
-    ]
   'property_values':
     'comment': 'Stuff that should only be available on values.'
     'patterns': [
@@ -1226,22 +1072,16 @@
         'include': '#constant_unit'
       }
       {
-        'include': '#constant_property_value'
-      }
-      {
         'include': '#constant_number'
       }
       {
-        'include': '#constant_font'
+        'include': 'source.css#property-keywords'
       }
       {
-        'include': '#constant_color'
+        'include': 'source.css#color-keywords'
       }
       {
-        'include': '#constant_deprecated_color'
-      }
-      {
-        'include': '#property_name' # Transitions can specify property names
+        'include': 'source.css#property-names' # Transitions can specify property names
       }
       {
         'include': '#constant_mathematical_symbols'
@@ -1440,34 +1280,6 @@
             'name': 'invalid.illegal.scss'
           }
         ]
-  'selector_entities':
-    'match': '''(?x)
-      \\b
-      (a|abbr|acronym|address|area|article|aside|audio|
-      b|base|bdi|bdo|big|blockquote|body|br|button|
-      canvas|caption|circle|cite|code|col|colgroup|
-      data|datalist|dd|del|details|dfn|dialog|div|dl|dt|
-      ellipse|em|embed|eventsource|
-      fieldset|figure|figcaption|footer|form|frame|frameset|
-      g|
-      (h[1-6])|head|header|hgroup|hr|html|
-      i|iframe|img|image|input|ins|
-      kbd|keygen|
-      label|legend|li|line(?!-)|link|
-      main|map|mark|menu|menuitem|meta|meter|
-      nav|noframes|noscript|
-      object(?!-)|ol|optgroup|option|output|
-      p|param|path|picture|polygon|polyline|pre|progress|
-      q|
-      rb|rect|rp|rt|rtc|ruby|
-      s|samp|script|section|select|small|source|span|strike|strong|style|sub|summary|sup|svg|
-      table(?!-)|tbody|td|template|text(?!-)|textarea|textpath|tfoot|th|thead|time|title|tr|track|tspan|tt|
-      u|ul|
-      var|video|
-      wbr)
-      \\b
-    '''
-    'name': 'entity.name.tag.scss'
   'selector_custom':
     'match': '\\b([a-zA-Z0-9]+(-[a-zA-Z0-9]+)+)(?=\\.|\\s++[^:]|\\s*[,\\[{]|:(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|nth-(child|last-child|of-type|last-of-type)|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid)(\\([0-9A-Za-z]*\\))?)'
     'name': 'entity.name.tag.custom.scss'
@@ -1610,30 +1422,14 @@
         ]
       }
       {
-        'match': '''(?x)
-          (:)\\b
-          (link|visited|hover|active|focus|target|lang|disabled|enabled|checked|
-          indeterminate|root|first-child|last-child|first-of-type|last-of-type|
-          only-child|only-of-type|empty|not|valid|invalid)\\b
-        '''
-        'captures':
-          '0':
-            'name': 'entity.other.attribute-name.pseudo-class.css'
-          '1':
-            'name': 'punctuation.definition.entity.css'
+        'include': 'source.css#pseudo-classes'
       }
     ]
-  'selector_pseudo_element':
-    'captures':
-      '1':
-        'name': 'punctuation.definition.entity.css'
-    'match': '(:+)((-(moz|webkit|ms)-)?(after|before|first-letter|first-line|selection))\\b'
-    'name': 'entity.other.attribute-name.pseudo-element.css'
   'selectors':
     'comment': 'Stuff for Selectors.'
     'patterns': [
       {
-        'include': '#selector_entities'
+        'include': 'source.css#tag-names'
       }
       {
         'include': '#selector_custom'
@@ -1654,7 +1450,7 @@
         'include': '#tag_parent_reference'
       }
       {
-        'include': '#selector_pseudo_element'
+        'include': 'source.css#pseudo-elements'
       }
       {
         'include': '#selector_attribute'

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -63,7 +63,7 @@
     'include': '#at_rule_supports'
   }
 ]
-# Note how all @rules are prefixed by "at_rule__".
+# Note how all @rules are prefixed by "at_rule_".
 'repository':
   # Charset
   'at_rule_charset':
@@ -464,7 +464,6 @@
                 ]
               }
               {
-                # Kuroir: fixed nested elements for sass.
                 'begin': '(:)\\s*(?!(\\s*{))'
                 'beginCaptures':
                   '1':
@@ -828,7 +827,6 @@
         'include': '#property_values'
       }
       {
-        # We even have error highlighting <3
         'match': '[={}\\?;@]'
         'name': 'invalid.illegal.scss'
       }
@@ -996,7 +994,6 @@
         ]
       }
       {
-        # Kuroir: fixed nested elements for sass.
         'begin': '(:)\\s*(?!(\\s*{))'
         'beginCaptures':
           '1':

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -1,7 +1,10 @@
-describe 'SASS grammar', ->
+describe 'Sass grammar', ->
   grammar = null
 
   beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage('language-css')
+
     waitsForPromise ->
       atom.packages.activatePackage('language-sass')
 
@@ -19,7 +22,7 @@ describe 'SASS grammar', ->
           -webkit-mask-repeat: no-repeat
       '''
 
-      expect(tokens[1][1]).toEqual value: '-webkit-mask-repeat', scopes: ['source.sass', 'meta.property-name.sass', 'support.type.property-name.css.sass']
+      expect(tokens[1][1]).toEqual value: '-webkit-mask-repeat', scopes: ['source.sass', 'meta.property-name.sass', 'support.type.vendored.property-name.css']
 
   describe 'numbers', ->
     it 'tokenizes them', ->

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -3,6 +3,9 @@ describe 'SCSS grammar', ->
 
   beforeEach ->
     waitsForPromise ->
+      atom.packages.activatePackage('language-css')
+
+    waitsForPromise ->
       atom.packages.activatePackage('language-sass')
 
     runs ->
@@ -197,10 +200,10 @@ describe 'SCSS grammar', ->
       expect(tokens[0][0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.page.scss', 'keyword.control.at-rule.page.scss', 'punctuation.definition.keyword.scss']
       expect(tokens[0][1]).toEqual value: 'page', scopes: ['source.css.scss', 'meta.at-rule.page.scss', 'keyword.control.at-rule.page.scss']
       expect(tokens[1][0]).toEqual value: '  ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[1][1]).toEqual value: 'text-align', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
+      expect(tokens[1][1]).toEqual value: 'text-align', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[1][2]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[1][3]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[1][4]).toEqual value: 'center', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.scss']
+      expect(tokens[1][4]).toEqual value: 'center', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
 
       tokens = grammar.tokenizeLines '''
         @page :left {
@@ -213,10 +216,10 @@ describe 'SCSS grammar', ->
       expect(tokens[0][2]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.at-rule.page.scss']
       expect(tokens[0][3]).toEqual value: ':left', scopes: ['source.css.scss', 'meta.at-rule.page.scss', 'entity.name.function.scss']
       expect(tokens[1][0]).toEqual value: '  ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[1][1]).toEqual value: 'text-align', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
+      expect(tokens[1][1]).toEqual value: 'text-align', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[1][2]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[1][3]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[1][4]).toEqual value: 'center', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.scss']
+      expect(tokens[1][4]).toEqual value: 'center', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
 
       tokens = grammar.tokenizeLines '''
         @page:left {
@@ -228,10 +231,10 @@ describe 'SCSS grammar', ->
       expect(tokens[0][1]).toEqual value: 'page', scopes: ['source.css.scss', 'meta.at-rule.page.scss', 'keyword.control.at-rule.page.scss']
       expect(tokens[0][2]).toEqual value: ':left', scopes: ['source.css.scss', 'meta.at-rule.page.scss', 'entity.name.function.scss']
       expect(tokens[1][0]).toEqual value: '  ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[1][1]).toEqual value: 'text-align', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
+      expect(tokens[1][1]).toEqual value: 'text-align', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[1][2]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[1][3]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[1][4]).toEqual value: 'center', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.scss']
+      expect(tokens[1][4]).toEqual value: 'center', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
 
   describe '@supports', ->
     it 'tokenizes solitary @supports', ->
@@ -247,9 +250,9 @@ describe 'SCSS grammar', ->
       expect(tokens[1]).toEqual value: 'supports', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'keyword.control.at-rule.supports.scss']
       expect(tokens[3]).toEqual value: 'not', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'keyword.operator.logical.scss']
       expect(tokens[5]).toEqual value: '(', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'punctuation.definition.condition.begin.bracket.round.scss']
-      expect(tokens[7]).toEqual value: 'display', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
+      expect(tokens[7]).toEqual value: 'display', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[8]).toEqual value: ':', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'punctuation.separator.key-value.scss']
-      expect(tokens[10]).toEqual value: 'flex', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'meta.property-value.scss', 'support.constant.property-value.scss']
+      expect(tokens[10]).toEqual value: 'flex', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
       expect(tokens[12]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'punctuation.definition.condition.end.bracket.round.scss']
       expect(tokens[13]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
 
@@ -259,12 +262,12 @@ describe 'SCSS grammar', ->
       expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'keyword.control.at-rule.supports.scss', 'punctuation.definition.keyword.scss']
       expect(tokens[1]).toEqual value: 'supports', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'keyword.control.at-rule.supports.scss']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'punctuation.definition.condition.begin.bracket.round.scss']
-      expect(tokens[4]).toEqual value: 'flex', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
+      expect(tokens[4]).toEqual value: 'flex', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[5]).toEqual value: ':', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[6]).toEqual value: '2', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'meta.property-value.scss', 'constant.numeric.scss']
       expect(tokens[9]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'punctuation.definition.condition.end.bracket.round.scss']
       expect(tokens[11]).toEqual value: 'or', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'keyword.operator.logical.scss']
-      expect(tokens[15]).toEqual value: '-webkit-flex', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
+      expect(tokens[15]).toEqual value: '-webkit-flex', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'meta.property-name.scss', 'support.type.vendored.property-name.css']
       expect(tokens[17]).toEqual value: ':', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[19]).toEqual value: '2', scopes: ['source.css.scss', 'meta.at-rule.supports.scss', 'meta.property-value.scss', 'constant.numeric.scss']
       expect(tokens[24]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
@@ -273,8 +276,8 @@ describe 'SCSS grammar', ->
     it 'tokenizes the property-name and property-value', ->
       {tokens} = grammar.tokenizeLine 'very-custom { color: inherit; }'
 
-      expect(tokens[4]).toEqual value: 'color', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
-      expect(tokens[7]).toEqual value: 'inherit', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.scss']
+      expect(tokens[4]).toEqual value: 'color', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
+      expect(tokens[7]).toEqual value: 'inherit', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
       expect(tokens[8]).toEqual value: ';', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.terminator.rule.scss']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.end.bracket.curly.scss']
 
@@ -284,19 +287,19 @@ describe 'SCSS grammar', ->
       expect(tokens[2]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
       expect(tokens[4]).toEqual value: 'very-very-custom', scopes: ['source.css.scss', 'meta.property-list.scss', 'entity.name.tag.custom.scss']
       expect(tokens[6]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
-      expect(tokens[8]).toEqual value: 'color', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
-      expect(tokens[11]).toEqual value: 'inherit', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.scss']
+      expect(tokens[8]).toEqual value: 'color', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
+      expect(tokens[11]).toEqual value: 'inherit', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
       expect(tokens[12]).toEqual value: ';', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-list.scss', 'punctuation.terminator.rule.scss']
       expect(tokens[14]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-list.scss', 'punctuation.section.property-list.end.bracket.curly.scss']
-      expect(tokens[16]).toEqual value: 'margin', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
-      expect(tokens[19]).toEqual value: 'top', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.scss']
+      expect(tokens[16]).toEqual value: 'margin', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
+      expect(tokens[19]).toEqual value: 'top', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
       expect(tokens[22]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.end.bracket.curly.scss']
 
     it 'tokenizes an incomplete inline property-list', ->
       {tokens} = grammar.tokenizeLine 'very-custom { color: inherit}'
 
-      expect(tokens[4]).toEqual value: 'color', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
-      expect(tokens[7]).toEqual value: 'inherit', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.scss']
+      expect(tokens[4]).toEqual value: 'color', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
+      expect(tokens[7]).toEqual value: 'inherit', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
       expect(tokens[8]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.end.bracket.curly.scss']
 
     it 'tokenizes multiple lines of incomplete property-list', ->
@@ -306,8 +309,8 @@ describe 'SCSS grammar', ->
       '''
 
       expect(tokens[0][0]).toEqual value: 'very-custom', scopes: ['source.css.scss', 'entity.name.tag.custom.scss']
-      expect(tokens[0][4]).toEqual value: 'color', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
-      expect(tokens[0][7]).toEqual value: 'inherit', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.scss']
+      expect(tokens[0][4]).toEqual value: 'color', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
+      expect(tokens[0][7]).toEqual value: 'inherit', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
       expect(tokens[0][9]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.end.bracket.curly.scss']
       expect(tokens[1][0]).toEqual value: 'another-one', scopes: ['source.css.scss', 'entity.name.tag.custom.scss']
       expect(tokens[1][10]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.end.bracket.curly.scss']
@@ -340,12 +343,12 @@ describe 'SCSS grammar', ->
         }
       '''
 
-      expect(tokens[0][0]).toEqual value: 'text', scopes: ['source.css.scss', 'entity.name.tag.scss']
+      expect(tokens[0][0]).toEqual value: 'text', scopes: ['source.css.scss', 'entity.name.tag.css']
       expect(tokens[1][0]).toEqual value: '  ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[1][1]).toEqual value: 'text-align', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
+      expect(tokens[1][1]).toEqual value: 'text-align', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[1][2]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[1][3]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[1][4]).toEqual value: 'center', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.scss']
+      expect(tokens[1][4]).toEqual value: 'center', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
 
       tokens = grammar.tokenizeLines '''
         table {
@@ -353,19 +356,19 @@ describe 'SCSS grammar', ->
         }
       '''
 
-      expect(tokens[0][0]).toEqual value: 'table', scopes: ['source.css.scss', 'entity.name.tag.scss']
+      expect(tokens[0][0]).toEqual value: 'table', scopes: ['source.css.scss', 'entity.name.tag.css']
       expect(tokens[1][0]).toEqual value: '  ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[1][1]).toEqual value: 'table-layout', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
+      expect(tokens[1][1]).toEqual value: 'table-layout', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[1][2]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[1][3]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[1][4]).toEqual value: 'fixed', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.scss']
+      expect(tokens[1][4]).toEqual value: 'fixed', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
 
   describe 'vendor properties', ->
     it 'tokenizes the browser prefix', ->
       {tokens} = grammar.tokenizeLine 'body { -webkit-box-shadow: none; }'
 
-      expect(tokens[0]).toEqual value: 'body', scopes: ['source.css.scss', 'entity.name.tag.scss']
-      expect(tokens[4]).toEqual value: '-webkit-box-shadow', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
+      expect(tokens[0]).toEqual value: 'body', scopes: ['source.css.scss', 'entity.name.tag.css']
+      expect(tokens[4]).toEqual value: '-webkit-box-shadow', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.vendored.property-name.css']
 
   describe 'custom elements', ->
     it 'tokenizes them as tags', ->
@@ -413,22 +416,22 @@ describe 'SCSS grammar', ->
       '''
 
       expect(tokens[1][0]).toEqual value: '  ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[1][1]).toEqual value: 'border-width', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
+      expect(tokens[1][1]).toEqual value: 'border-width', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[1][2]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[1][3]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss']
       expect(tokens[1][4]).toEqual value: '2', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss']
       expect(tokens[2][0]).toEqual value: '  ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[2][1]).toEqual value: 'font-size', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
+      expect(tokens[2][1]).toEqual value: 'font-size', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[2][2]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss']
       expect(tokens[2][3]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[2][4]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss']
       expect(tokens[2][5]).toEqual value: '2', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss']
       expect(tokens[3][0]).toEqual value: '  ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[3][1]).toEqual value: 'background-image', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
+      expect(tokens[3][1]).toEqual value: 'background-image', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[3][2]).toEqual value: '  ', scopes: ['source.css.scss', 'meta.property-list.scss']
       expect(tokens[3][3]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[3][4]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[3][5]).toEqual value: 'none', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.scss']
+      expect(tokens[3][5]).toEqual value: 'none', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
 
   describe 'pseudo classes', ->
     it 'tokenizes them', ->
@@ -511,10 +514,10 @@ describe 'SCSS grammar', ->
       expect(tokens[0][3]).toEqual value: 'anim', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'entity.name.function.scss']
       expect(tokens[0][5]).toEqual value: '{', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'punctuation.section.keyframes.begin.scss']
       expect(tokens[1][1]).toEqual value: 'from', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'entity.other.attribute-name.scss']
-      expect(tokens[1][5]).toEqual value: 'opacity', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
+      expect(tokens[1][5]).toEqual value: 'opacity', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[1][8]).toEqual value: '0', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss']
       expect(tokens[2][1]).toEqual value: 'to', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'entity.other.attribute-name.scss']
-      expect(tokens[2][5]).toEqual value: 'opacity', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.scss']
+      expect(tokens[2][5]).toEqual value: 'opacity', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[2][8]).toEqual value: '1', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.scss']
       expect(tokens[3][0]).toEqual value: '}', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'punctuation.section.keyframes.end.scss']
 
@@ -546,7 +549,7 @@ describe 'SCSS grammar', ->
       expect(tokens[4]).toEqual value: 'orientation', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'meta.property-name.media-query.scss', 'support.type.property-name.media.css']
       expect(tokens[5]).toEqual value: ':', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[6]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss']
-      expect(tokens[7]).toEqual value: 'landscape', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'meta.property-value.media-query.scss', 'support.constant.property-value.scss']
+      expect(tokens[7]).toEqual value: 'landscape', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'meta.property-value.media-query.scss', 'support.constant.property-value.css']
       expect(tokens[8]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.definition.media-query.end.bracket.round.scss']
       expect(tokens[9]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.at-rule.media.scss']
       expect(tokens[10]).toEqual value: 'and', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.operator.logical.scss']


### PR DESCRIPTION
See atom/language-less#73. This PR links the package with `language-css` so Sass, Less and CSS all share the same keyword lists. No more copy+pasta.

### Applicable Issues

I had to remove the [`#property_name_error`](https://github.com/atom/language-sass/blob/f992d44/grammars/scss.cson#L1155-L1188) block in order to achieve this. It doesn't even appear to be necessary, anyway.

/cc @50Wliu 