### PR TITLE
Rework property-value

### DIFF
--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -490,7 +490,7 @@
   }
   {
     # property-name: property-value
-    'begin': '^\\s+([-A-Za-z]+)\\s*(?=(\\|\\|)?=|:\\s+)'
+    'begin': '^\\s+([-A-Za-z]+)\\s*(?=(\\|\\|)?=|:[ \\t]+)'
     'beginCaptures':
       '1':
         'patterns': [

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -6,14 +6,14 @@
 ]
 'patterns': [
   {
-    'begin': '(!|\\$)([a-zA-Z0-9_-]+)\\s*((?:\\|\\|)?=|:)'
+    'begin': '(?:(!)|(\\$))([a-zA-Z0-9_-]+)\\s*(?=(\\|\\|)?=|:\\s+)'
     'beginCaptures':
       '1':
-        'name': 'punctuation.definition.entity.sass'
+        'name': 'invalid.illegal.deprecated.sass'
       '2':
-        'name': 'variable.other.sass'
+        'name': 'punctuation.definition.entity.sass'
       '3':
-        'name': 'punctuation.separator.operator.sass'
+        'name': 'variable.other.sass'
     'end': '(;)?$'
     'endCaptures':
       '1':
@@ -21,7 +21,19 @@
     'name': 'meta.variable-declaration.sass'
     'patterns': [
       {
-        'include': '#property-value'
+        'begin': '(?:(:)\\s+)|((\\|\\|)?=)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.separator.key-value.css'
+          '2':
+            'name': 'invalid.illegal.deprecated.sass'
+        'end': '(?=;?$)'
+        'name': 'meta.property-value.sass'
+        'patterns': [
+          {
+            'include': '#property-value'
+          }
+        ]
       }
     ]
   }
@@ -364,24 +376,6 @@
         'match': '(?<=&)[a-zA-Z0-9_-]+'
         'name': 'entity.other.attribute-name.parent-selector-suffix.css.sass'
       }
-      {
-        'match': '(?<!$)([a-zA-Z0-9_-]+)\\s*(:)(.*)$'
-        'captures':
-          '1':
-            'patterns': [
-              {
-                'include': 'source.css#property-names'
-              }
-            ]
-          '2':
-            'name': 'punctuation.separator.operator.sass'
-          '3':
-            'patterns': [
-              {
-                'include': '#property-value'
-              }
-            ]
-      }
     ]
   }
   {
@@ -469,10 +463,11 @@
     ]
   }
   {
+    # :property-name property-value
     'begin': '(?<!|\\$[-a-z])(:)(?=[-a-z])'
     'beginCaptures':
       '1':
-        'name': 'punctuation.definition.entity.css.sass'
+        'name': 'punctuation.separator.key-value.css'
     'end': '(;)?$'
     'endCaptures':
       '1':
@@ -488,29 +483,38 @@
     ]
   }
   {
-    'begin': '''(?x)
-      ^
-      \\s+
-      ([-A-Za-z]+)
-      (\\s*:|\\s?=)
-    '''
+    # property-name: property-value
+    'begin': '^\\s+([-A-Za-z]+)\\s*(?=(\\|\\|)?=|:\\s+)'
     'beginCaptures':
       '1':
         'patterns': [
           {
-            'include': 'source.css#property-names'
+            'include': '#property-name'
           }
         ]
       '2':
-        'name': 'punctuation.definition.entity.css.sass'
+        'name': 'punctuation.separator.key-value.css'
+      '3':
+        'name': 'invalid.illegal.deprecated.sass'
     'end': '(;)?$'
     'endCaptures':
       '1':
         'name': 'invalid.illegal.punctuation.sass'
-    'name': 'meta.property-name.sass'
     'patterns': [
       {
-        'include': '#property-value'
+        'begin': '(?:(:)\\s+)|((\\|\\|)?=)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.separator.key-value.css'
+          '2':
+            'name': 'invalid.illegal.deprecated.sass'
+        'end': '(?=;?$)'
+        'name': 'meta.property-value.sass'
+        'patterns': [
+          {
+            'include': '#property-value'
+          }
+        ]
       }
     ]
   }
@@ -544,16 +548,21 @@
         'name': 'comment.line.sass'
       }
     ]
+  'property-name':
+    'begin': '(?=[-A-Za-z]+)'
+    'end': '(?!\\G)'
+    'name': 'meta.property-name.sass'
+    'patterns': [
+      {
+        'include': 'source.css#property-names'
+      }
+    ]
   'property-value':
-    'begin': '(:)?\\s?+'
+    'begin': '(:)|\\G'
     'beginCaptures':
       '1':
         'name': 'invalid.illegal.punctuation.sass'
-    'end': '(;)?$'
-    'endCaptures':
-      '1':
-        'name': 'invalid.illegal.punctuation.sass'
-    'name': 'meta.property-value.sass'
+    'end': '(?=;?$)'
     'patterns': [
       {
         'match': '\\b[0-9]+(\\.[0-9]+)?'

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -490,6 +490,8 @@
   }
   {
     # property-name: property-value
+    # Note: this pattern is very specific. Make sure that
+    # autocomplete-css specs still pass if making changes here.
     'begin': '^\\s+([-A-Za-z]+)\\s*(?=(\\|\\|)?=|:[ \\t]+)'
     'beginCaptures':
       '1':

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -464,7 +464,7 @@
   }
   {
     # :property-name property-value
-    'begin': '(?<!|\\$[-a-z])(:)(?=[-a-z])'
+    'begin': '^\\s+(:)(?=[-a-z])'
     'beginCaptures':
       '1':
         'name': 'punctuation.separator.key-value.css'
@@ -472,13 +472,19 @@
     'endCaptures':
       '1':
         'name': 'invalid.illegal.punctuation.sass'
-    'name': 'meta.property-name.sass'
     'patterns': [
       {
-        'include': 'source.css#property-names'
+        'include': '#property-name'
       }
       {
-        'include': '#property-value'
+        'begin': '\\s+'
+        'end': '(?=;?$)'
+        'name': 'meta.property-value.sass'
+        'patterns': [
+          {
+            'include': '#property-value'
+          }
+        ]
       }
     ]
   }

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -50,6 +50,32 @@ describe 'Sass grammar', ->
       expect(tokens[3][3]).toEqual value: ' ', scopes: ['source.sass', 'meta.property-value.sass']
       expect(tokens[3][4]).toEqual value: 'top', scopes: ['source.sass', 'meta.property-value.sass', 'support.constant.property-value.css']
 
+    it 'tokenizes colon-first property-list syntax', ->
+      tokens = grammar.tokenizeLines '''
+        very-custom
+          :color inherit
+      '''
+      expect(tokens[1][1]).toEqual value: ':', scopes: ['source.sass', 'punctuation.separator.key-value.css']
+      expect(tokens[1][2]).toEqual value: 'color', scopes: ['source.sass', 'meta.property-name.sass', 'support.type.property-name.css']
+      expect(tokens[1][3]).toEqual value: ' ', scopes: ['source.sass', 'meta.property-value.sass']
+      expect(tokens[1][4]).toEqual value: 'inherit', scopes: ['source.sass', 'meta.property-value.sass', 'support.constant.property-value.css']
+
+    it 'tokenizes nested colon-first property-list syntax', ->
+      tokens = grammar.tokenizeLines '''
+        very-custom
+          very-very-custom
+            :color inherit
+          :margin top
+      '''
+      expect(tokens[2][1]).toEqual value: ':', scopes: ['source.sass', 'punctuation.separator.key-value.css']
+      expect(tokens[2][2]).toEqual value: 'color', scopes: ['source.sass', 'meta.property-name.sass', 'support.type.property-name.css']
+      expect(tokens[2][3]).toEqual value: ' ', scopes: ['source.sass', 'meta.property-value.sass']
+      expect(tokens[2][4]).toEqual value: 'inherit', scopes: ['source.sass', 'meta.property-value.sass', 'support.constant.property-value.css']
+      expect(tokens[3][1]).toEqual value: ':', scopes: ['source.sass', 'punctuation.separator.key-value.css']
+      expect(tokens[3][2]).toEqual value: 'margin', scopes: ['source.sass', 'meta.property-name.sass', 'support.type.property-name.css']
+      expect(tokens[3][3]).toEqual value: ' ', scopes: ['source.sass', 'meta.property-value.sass']
+      expect(tokens[3][4]).toEqual value: 'top', scopes: ['source.sass', 'meta.property-value.sass', 'support.constant.property-value.css']
+
   describe 'pseudo-classes and pseudo-elements', ->
     it 'tokenizes pseudo-classes', ->
       tokens = grammar.tokenizeLines '''

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -21,8 +21,74 @@ describe 'Sass grammar', ->
         .something
           -webkit-mask-repeat: no-repeat
       '''
-
       expect(tokens[1][1]).toEqual value: '-webkit-mask-repeat', scopes: ['source.sass', 'meta.property-name.sass', 'support.type.vendored.property-name.css']
+
+  describe 'property-list', ->
+    it 'tokenizes the property-name and property-value', ->
+      tokens = grammar.tokenizeLines '''
+        very-custom
+          color: inherit
+      '''
+      expect(tokens[1][1]).toEqual value: 'color', scopes: ['source.sass', 'meta.property-name.sass', 'support.type.property-name.css']
+      expect(tokens[1][2]).toEqual value: ':', scopes: ['source.sass', 'meta.property-value.sass', 'punctuation.separator.key-value.css']
+      expect(tokens[1][3]).toEqual value: ' ', scopes: ['source.sass', 'meta.property-value.sass']
+      expect(tokens[1][4]).toEqual value: 'inherit', scopes: ['source.sass', 'meta.property-value.sass', 'support.constant.property-value.css']
+
+    it 'tokenizes nested property-lists', ->
+      tokens = grammar.tokenizeLines '''
+        very-custom
+          very-very-custom
+            color: inherit
+          margin: top
+      '''
+      expect(tokens[2][1]).toEqual value: 'color', scopes: ['source.sass', 'meta.property-name.sass', 'support.type.property-name.css']
+      expect(tokens[2][2]).toEqual value: ':', scopes: ['source.sass', 'meta.property-value.sass', 'punctuation.separator.key-value.css']
+      expect(tokens[2][3]).toEqual value: ' ', scopes: ['source.sass', 'meta.property-value.sass']
+      expect(tokens[2][4]).toEqual value: 'inherit', scopes: ['source.sass', 'meta.property-value.sass', 'support.constant.property-value.css']
+      expect(tokens[3][1]).toEqual value: 'margin', scopes: ['source.sass', 'meta.property-name.sass', 'support.type.property-name.css']
+      expect(tokens[3][2]).toEqual value: ':', scopes: ['source.sass', 'meta.property-value.sass', 'punctuation.separator.key-value.css']
+      expect(tokens[3][3]).toEqual value: ' ', scopes: ['source.sass', 'meta.property-value.sass']
+      expect(tokens[3][4]).toEqual value: 'top', scopes: ['source.sass', 'meta.property-value.sass', 'support.constant.property-value.css']
+
+  describe 'pseudo-classes and pseudo-elements', ->
+    it 'tokenizes pseudo-classes', ->
+      tokens = grammar.tokenizeLines '''
+        a:hover
+          display: none
+      '''
+      expect(tokens[0][0]).toEqual value: 'a', scopes: ['source.sass', 'meta.selector.css', 'entity.name.tag.css']
+      expect(tokens[0][1]).toEqual value: ':', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
+      expect(tokens[0][2]).toEqual value: 'hover', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
+
+    it 'tokenizes pseudo-elements', ->
+      tokens = grammar.tokenizeLines '''
+        a::before
+          display: none
+      '''
+
+      expect(tokens[0][0]).toEqual value: 'a', scopes: ['source.sass', 'meta.selector.css', 'entity.name.tag.css']
+      expect(tokens[0][1]).toEqual value: '::', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css', 'punctuation.definition.entity.css']
+      expect(tokens[0][2]).toEqual value: 'before', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css']
+
+    it 'tokenizes nested pseudo-classes', ->
+      tokens = grammar.tokenizeLines '''
+        body
+          a:hover
+            display: none
+      '''
+      expect(tokens[1][1]).toEqual value: 'a', scopes: ['source.sass', 'meta.selector.css', 'entity.name.tag.css']
+      expect(tokens[1][2]).toEqual value: ':', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
+      expect(tokens[1][3]).toEqual value: 'hover', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
+
+    it 'tokenizes nested pseudo-elements', ->
+      tokens = grammar.tokenizeLines '''
+        body
+          a::before
+            display: none
+      '''
+      expect(tokens[1][1]).toEqual value: 'a', scopes: ['source.sass', 'meta.selector.css', 'entity.name.tag.css']
+      expect(tokens[1][2]).toEqual value: '::', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css', 'punctuation.definition.entity.css']
+      expect(tokens[1][3]).toEqual value: 'before', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css']
 
   describe 'numbers', ->
     it 'tokenizes them', ->
@@ -30,24 +96,21 @@ describe 'Sass grammar', ->
         .something
           top: 50%
       '''
-
-      expect(tokens[1][4]).toEqual value: '50', scopes: ['source.sass', 'meta.property-name.sass', 'meta.property-value.sass', 'constant.numeric.css']
+      expect(tokens[1][4]).toEqual value: '50', scopes: ['source.sass', 'meta.property-value.sass', 'constant.numeric.css']
 
     it 'tokenizes number operations', ->
       tokens = grammar.tokenizeLines '''
         .something
           top: +50%
       '''
-
-      expect(tokens[1][4]).toEqual value: '+', scopes: ['source.sass', 'meta.property-name.sass', 'meta.property-value.sass', 'keyword.operator.css']
-      expect(tokens[1][5]).toEqual value: '50', scopes: ['source.sass', 'meta.property-name.sass', 'meta.property-value.sass', 'constant.numeric.css']
+      expect(tokens[1][4]).toEqual value: '+', scopes: ['source.sass', 'meta.property-value.sass', 'keyword.operator.css']
+      expect(tokens[1][5]).toEqual value: '50', scopes: ['source.sass', 'meta.property-value.sass', 'constant.numeric.css']
 
       tokens = grammar.tokenizeLines '''
         .something
           top: 50% - 30%
       '''
-
-      expect(tokens[1][7]).toEqual value: '-', scopes: ['source.sass', 'meta.property-name.sass', 'meta.property-value.sass', 'keyword.operator.css']
+      expect(tokens[1][7]).toEqual value: '-', scopes: ['source.sass', 'meta.property-value.sass', 'keyword.operator.css']
 
   describe 'variables', ->
     it 'tokenizes them', ->
@@ -55,7 +118,7 @@ describe 'Sass grammar', ->
 
       expect(tokens[0]).toEqual value: '$', scopes: ['source.sass', 'meta.variable-declaration.sass', 'punctuation.definition.entity.sass']
       expect(tokens[1]).toEqual value: 'test', scopes: ['source.sass', 'meta.variable-declaration.sass', 'variable.other.sass']
-      expect(tokens[2]).toEqual value: ':', scopes: ['source.sass', 'meta.variable-declaration.sass', 'punctuation.separator.operator.sass']
+      expect(tokens[2]).toEqual value: ':', scopes: ['source.sass', 'meta.variable-declaration.sass', 'meta.property-value.sass', 'punctuation.separator.key-value.css']
       expect(tokens[3]).toEqual value: ' ', scopes: ['source.sass', 'meta.variable-declaration.sass', 'meta.property-value.sass']
       expect(tokens[4]).toEqual value: 'bla', scopes: ['source.sass', 'meta.variable-declaration.sass', 'meta.property-value.sass']
 
@@ -64,7 +127,7 @@ describe 'Sass grammar', ->
 
       expect(tokens[1]).toEqual value: '$', scopes: ['source.sass', 'meta.variable-declaration.sass', 'punctuation.definition.entity.sass']
       expect(tokens[2]).toEqual value: 'test', scopes: ['source.sass', 'meta.variable-declaration.sass', 'variable.other.sass']
-      expect(tokens[3]).toEqual value: ':', scopes: ['source.sass', 'meta.variable-declaration.sass', 'punctuation.separator.operator.sass']
+      expect(tokens[3]).toEqual value: ':', scopes: ['source.sass', 'meta.variable-declaration.sass', 'meta.property-value.sass', 'punctuation.separator.key-value.css']
       expect(tokens[4]).toEqual value: ' ', scopes: ['source.sass', 'meta.variable-declaration.sass', 'meta.property-value.sass']
       expect(tokens[5]).toEqual value: 'bla', scopes: ['source.sass', 'meta.variable-declaration.sass', 'meta.property-value.sass']
 
@@ -74,35 +137,31 @@ describe 'Sass grammar', ->
         .a
           content: 'hi'
       """
-
-      expect(tokens[1][4]).toEqual value: "'", scopes: ['source.sass', 'meta.property-name.sass', 'meta.property-value.sass', 'string.quoted.single.sass', 'punctuation.definition.string.begin.sass']
-      expect(tokens[1][5]).toEqual value: 'hi', scopes: ['source.sass', 'meta.property-name.sass', 'meta.property-value.sass', 'string.quoted.single.sass']
-      expect(tokens[1][6]).toEqual value: "'", scopes: ['source.sass', 'meta.property-name.sass', 'meta.property-value.sass', 'string.quoted.single.sass', 'punctuation.definition.string.end.sass']
+      expect(tokens[1][4]).toEqual value: "'", scopes: ['source.sass', 'meta.property-value.sass', 'string.quoted.single.sass', 'punctuation.definition.string.begin.sass']
+      expect(tokens[1][5]).toEqual value: 'hi', scopes: ['source.sass', 'meta.property-value.sass', 'string.quoted.single.sass']
+      expect(tokens[1][6]).toEqual value: "'", scopes: ['source.sass', 'meta.property-value.sass', 'string.quoted.single.sass', 'punctuation.definition.string.end.sass']
 
     it 'tokenizes double-quote strings', ->
       tokens = grammar.tokenizeLines '''
         .a
           content: "hi"
       '''
-
-      expect(tokens[1][4]).toEqual value: '"', scopes: ['source.sass', 'meta.property-name.sass', 'meta.property-value.sass', 'string.quoted.double.sass', 'punctuation.definition.string.begin.sass']
-      expect(tokens[1][5]).toEqual value: 'hi', scopes: ['source.sass', 'meta.property-name.sass', 'meta.property-value.sass', 'string.quoted.double.sass']
-      expect(tokens[1][6]).toEqual value: '"', scopes: ['source.sass', 'meta.property-name.sass', 'meta.property-value.sass', 'string.quoted.double.sass', 'punctuation.definition.string.end.sass']
+      expect(tokens[1][4]).toEqual value: '"', scopes: ['source.sass', 'meta.property-value.sass', 'string.quoted.double.sass', 'punctuation.definition.string.begin.sass']
+      expect(tokens[1][5]).toEqual value: 'hi', scopes: ['source.sass', 'meta.property-value.sass', 'string.quoted.double.sass']
+      expect(tokens[1][6]).toEqual value: '"', scopes: ['source.sass', 'meta.property-value.sass', 'string.quoted.double.sass', 'punctuation.definition.string.end.sass']
 
     it 'tokenizes escape characters', ->
       tokens = grammar.tokenizeLines """
         .a
           content: '\\abcdef'
       """
-
-      expect(tokens[1][5]).toEqual value: '\\abcdef', scopes: ['source.sass', 'meta.property-name.sass', 'meta.property-value.sass', 'string.quoted.single.sass', 'constant.character.escape.sass']
+      expect(tokens[1][5]).toEqual value: '\\abcdef', scopes: ['source.sass', 'meta.property-value.sass', 'string.quoted.single.sass', 'constant.character.escape.sass']
 
       tokens = grammar.tokenizeLines '''
         .a
           content: "\\abcdef"
       '''
-
-      expect(tokens[1][5]).toEqual value: '\\abcdef', scopes: ['source.sass', 'meta.property-name.sass', 'meta.property-value.sass', 'string.quoted.double.sass', 'constant.character.escape.sass']
+      expect(tokens[1][5]).toEqual value: '\\abcdef', scopes: ['source.sass', 'meta.property-value.sass', 'string.quoted.double.sass', 'constant.character.escape.sass']
 
   describe 'comments', ->
     it 'only tokenizes comments that start at the beginning of a line', ->
@@ -130,7 +189,6 @@ describe 'Sass grammar', ->
           hi2
         hi3
       '''
-
       expect(tokens[0][0]).toEqual value: '/*', scopes: ['source.sass', 'comment.block.sass', 'punctuation.definition.comment.sass']
       expect(tokens[0][1]).toEqual value: ' hi1', scopes: ['source.sass', 'comment.block.sass']
       expect(tokens[1][0]).toEqual value: '  hi2', scopes: ['source.sass', 'comment.block.sass']
@@ -142,7 +200,6 @@ describe 'Sass grammar', ->
           hi2
         hi3
       '''
-
       expect(tokens[0][0]).toEqual value: '//', scopes: ['source.sass', 'comment.line.sass', 'punctuation.definition.comment.sass']
       expect(tokens[0][1]).toEqual value: ' hi1', scopes: ['source.sass', 'comment.line.sass']
       expect(tokens[1][0]).toEqual value: '  hi2', scopes: ['source.sass', 'comment.line.sass']
@@ -154,60 +211,60 @@ describe 'Sass grammar', ->
       expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.function.sass', 'keyword.control.at-rule.function.sass', 'punctuation.definition.entity.sass']
       expect(tokens[1]).toEqual value: 'function', scopes: ['source.sass', 'meta.at-rule.function.sass', 'keyword.control.at-rule.function.sass']
       expect(tokens[3]).toEqual value: 'function_name', scopes: ['source.sass', 'meta.at-rule.function.sass', 'support.function.misc.sass']
-      expect(tokens[5]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.function.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
-      expect(tokens[6]).toEqual value: 'p1', scopes: ['source.sass', 'meta.at-rule.function.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'variable.other.sass']
-      expect(tokens[8]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.function.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
-      expect(tokens[9]).toEqual value: 'p2', scopes: ['source.sass', 'meta.at-rule.function.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+      expect(tokens[5]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.function.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+      expect(tokens[6]).toEqual value: 'p1', scopes: ['source.sass', 'meta.at-rule.function.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+      expect(tokens[8]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.function.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+      expect(tokens[9]).toEqual value: 'p2', scopes: ['source.sass', 'meta.at-rule.function.sass', 'meta.variable-usage.sass', 'variable.other.sass']
 
     it 'tokenizes @return', ->
       {tokens} = grammar.tokenizeLine '@return \'border\' + \' \' + \'1px solid pink\''
       expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.return.sass', 'keyword.control.return.sass', 'punctuation.definition.entity.sass']
       expect(tokens[1]).toEqual value: 'return', scopes: ['source.sass', 'meta.at-rule.return.sass', 'keyword.control.return.sass']
-      expect(tokens[4]).toEqual value: 'border', scopes: ['source.sass', 'meta.at-rule.return.sass', 'meta.property-value.sass', 'string.quoted.single.sass']
-      expect(tokens[7]).toEqual value: '+', scopes: ['source.sass', 'meta.at-rule.return.sass', 'meta.property-value.sass', 'keyword.operator.css']
+      expect(tokens[4]).toEqual value: 'border', scopes: ['source.sass', 'meta.at-rule.return.sass', 'string.quoted.single.sass']
+      expect(tokens[7]).toEqual value: '+', scopes: ['source.sass', 'meta.at-rule.return.sass', 'keyword.operator.css']
 
     it 'tokenizes @if', ->
       {tokens} = grammar.tokenizeLine '@if $var == true'
       expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.control.if.sass', 'punctuation.definition.entity.sass']
       expect(tokens[1]).toEqual value: 'if', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.control.if.sass']
-      expect(tokens[3]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
-      expect(tokens[4]).toEqual value: 'var', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'variable.other.sass']
-      expect(tokens[6]).toEqual value: '==', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.property-value.sass', 'keyword.operator.comparison.sass']
-      expect(tokens[8]).toEqual value: 'true', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.property-value.sass', 'support.constant.property-value.css.sass']
+      expect(tokens[3]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+      expect(tokens[4]).toEqual value: 'var', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+      expect(tokens[6]).toEqual value: '==', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.operator.comparison.sass']
+      expect(tokens[8]).toEqual value: 'true', scopes: ['source.sass', 'meta.at-rule.if.sass', 'support.constant.property-value.css.sass']
 
     it 'tokenizes @else if', ->
       {tokens} = grammar.tokenizeLine '@else if $var == false'
       expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.else.sass', 'keyword.control.else.sass', 'punctuation.definition.entity.sass']
       expect(tokens[1]).toEqual value: 'else if ', scopes: ['source.sass', 'meta.at-rule.else.sass', 'keyword.control.else.sass']
-      expect(tokens[2]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
-      expect(tokens[3]).toEqual value: 'var', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'variable.other.sass']
-      expect(tokens[5]).toEqual value: '==', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.property-value.sass', 'keyword.operator.comparison.sass']
-      expect(tokens[7]).toEqual value: 'false', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.property-value.sass', 'support.constant.property-value.css.sass']
+      expect(tokens[2]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+      expect(tokens[3]).toEqual value: 'var', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+      expect(tokens[5]).toEqual value: '==', scopes: ['source.sass', 'meta.at-rule.else.sass', 'keyword.operator.comparison.sass']
+      expect(tokens[7]).toEqual value: 'false', scopes: ['source.sass', 'meta.at-rule.else.sass', 'support.constant.property-value.css.sass']
 
     it 'tokenizes @while', ->
       {tokens} = grammar.tokenizeLine '@while 1'
       expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.while.sass', 'keyword.control.while.sass', 'punctuation.definition.entity.sass']
       expect(tokens[1]).toEqual value: 'while', scopes: ['source.sass', 'meta.at-rule.while.sass', 'keyword.control.while.sass']
-      expect(tokens[3]).toEqual value: '1', scopes: ['source.sass', 'meta.at-rule.while.sass', 'meta.property-value.sass', 'constant.numeric.css']
+      expect(tokens[3]).toEqual value: '1', scopes: ['source.sass', 'meta.at-rule.while.sass', 'constant.numeric.css']
 
     it 'tokenizes @for', ->
       {tokens} = grammar.tokenizeLine '@for $i from 1 through 100'
       expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.for.sass', 'keyword.control.for.sass', 'punctuation.definition.entity.sass']
       expect(tokens[1]).toEqual value: 'for', scopes: ['source.sass', 'meta.at-rule.for.sass', 'keyword.control.for.sass']
-      expect(tokens[3]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.for.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
-      expect(tokens[4]).toEqual value: 'i', scopes: ['source.sass', 'meta.at-rule.for.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'variable.other.sass']
-      expect(tokens[8]).toEqual value: '1', scopes: ['source.sass', 'meta.at-rule.for.sass', 'meta.property-value.sass', 'constant.numeric.css']
-      expect(tokens[12]).toEqual value: '100', scopes: ['source.sass', 'meta.at-rule.for.sass', 'meta.property-value.sass', 'constant.numeric.css']
+      expect(tokens[3]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.for.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+      expect(tokens[4]).toEqual value: 'i', scopes: ['source.sass', 'meta.at-rule.for.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+      expect(tokens[8]).toEqual value: '1', scopes: ['source.sass', 'meta.at-rule.for.sass', 'constant.numeric.css']
+      expect(tokens[12]).toEqual value: '100', scopes: ['source.sass', 'meta.at-rule.for.sass', 'constant.numeric.css']
       # 'from' and 'thorugh' tested in operators
 
     it 'tokenizes @each', ->
       {tokens} = grammar.tokenizeLine '@each $item in $list'
       expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.each.sass', 'keyword.control.each.sass', 'punctuation.definition.entity.sass']
       expect(tokens[1]).toEqual value: 'each', scopes: ['source.sass', 'meta.at-rule.each.sass', 'keyword.control.each.sass']
-      expect(tokens[3]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
-      expect(tokens[4]).toEqual value: 'item', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'variable.other.sass']
-      expect(tokens[8]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
-      expect(tokens[9]).toEqual value: 'list', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+      expect(tokens[3]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+      expect(tokens[4]).toEqual value: 'item', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+      expect(tokens[8]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+      expect(tokens[9]).toEqual value: 'list', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'variable.other.sass']
       # 'in' tested in operators
 
     it 'tokenizes @include or \'+\'', ->
@@ -224,19 +281,20 @@ describe 'Sass grammar', ->
       expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.variable-declaration.sass.mixin', 'keyword.control.at-rule.mixin.sass', 'punctuation.definition.entity.sass']
       expect(tokens[1]).toEqual value: 'mixin', scopes: ['source.sass', 'meta.variable-declaration.sass.mixin', 'keyword.control.at-rule.mixin.sass']
       expect(tokens[3]).toEqual value: 'mixin-name', scopes: ['source.sass', 'meta.variable-declaration.sass.mixin', 'variable.other.sass']
-      expect(tokens[5]).toEqual value: '$', scopes: ['source.sass', 'meta.variable-declaration.sass.mixin', 'meta.property-value.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
-      expect(tokens[6]).toEqual value: 'p', scopes: ['source.sass', 'meta.variable-declaration.sass.mixin', 'meta.property-value.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+      expect(tokens[5]).toEqual value: '$', scopes: ['source.sass', 'meta.variable-declaration.sass.mixin', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+      expect(tokens[6]).toEqual value: 'p', scopes: ['source.sass', 'meta.variable-declaration.sass.mixin', 'meta.variable-usage.sass', 'variable.other.sass']
 
       {tokens} = grammar.tokenizeLine '=mixin-name($p)'
       expect(tokens[0]).toEqual value: '\=', scopes: ['source.sass', 'meta.variable-declaration.sass.mixin', 'keyword.control.at-rule.keyframes.sass']
       expect(tokens[1]).toEqual value: 'mixin-name', scopes: ['source.sass', 'meta.variable-declaration.sass.mixin', 'variable.other.sass']
-      expect(tokens[3]).toEqual value: '$', scopes: ['source.sass', 'meta.variable-declaration.sass.mixin', 'meta.property-value.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
-      expect(tokens[4]).toEqual value: 'p', scopes: ['source.sass', 'meta.variable-declaration.sass.mixin', 'meta.property-value.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+      expect(tokens[3]).toEqual value: '$', scopes: ['source.sass', 'meta.variable-declaration.sass.mixin', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+      expect(tokens[4]).toEqual value: 'p', scopes: ['source.sass', 'meta.variable-declaration.sass.mixin', 'meta.variable-usage.sass', 'variable.other.sass']
 
     it 'tokenizes @content', ->
       tokens = grammar.tokenizeLines '''
         @mixin mixin-name($p)
-          @content'''
+          @content
+      '''
       expect(tokens[1][1]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.content.sass', 'keyword.control.content.sass', 'punctuation.definition.entity.sass']
       expect(tokens[1][2]).toEqual value: 'content', scopes: ['source.sass', 'meta.at-rule.content.sass', 'keyword.control.content.sass']
 
@@ -270,39 +328,39 @@ describe 'Sass grammar', ->
   describe 'operators', ->
     it 'correctly tokenizes comparison and logical operators', ->
       {tokens} = grammar.tokenizeLine '@if 1 == 1'
-      expect(tokens[5]).toEqual value: '==', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.property-value.sass', 'keyword.operator.comparison.sass']
+      expect(tokens[5]).toEqual value: '==', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.operator.comparison.sass']
 
       {tokens} = grammar.tokenizeLine '@if 1 != 1'
-      expect(tokens[5]).toEqual value: '!=', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.property-value.sass', 'keyword.operator.comparison.sass']
+      expect(tokens[5]).toEqual value: '!=', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.operator.comparison.sass']
 
       {tokens} = grammar.tokenizeLine '@if 1 > 1'
-      expect(tokens[5]).toEqual value: '>', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.property-value.sass', 'keyword.operator.comparison.sass']
+      expect(tokens[5]).toEqual value: '>', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.operator.comparison.sass']
 
       {tokens} = grammar.tokenizeLine '@if 1 < 1'
-      expect(tokens[5]).toEqual value: '<', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.property-value.sass', 'keyword.operator.comparison.sass']
+      expect(tokens[5]).toEqual value: '<', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.operator.comparison.sass']
 
       {tokens} = grammar.tokenizeLine '@if 1 >= 1'
-      expect(tokens[5]).toEqual value: '>=', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.property-value.sass', 'keyword.operator.comparison.sass']
+      expect(tokens[5]).toEqual value: '>=', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.operator.comparison.sass']
 
       {tokens} = grammar.tokenizeLine '@if 1 <= 1'
-      expect(tokens[5]).toEqual value: '<=', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.property-value.sass', 'keyword.operator.comparison.sass']
+      expect(tokens[5]).toEqual value: '<=', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.operator.comparison.sass']
 
       {tokens} = grammar.tokenizeLine '@if 1 == 1 and 2 == 2'
-      expect(tokens[9]).toEqual value: 'and', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.property-value.sass', 'keyword.operator.logical.sass']
+      expect(tokens[9]).toEqual value: 'and', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.operator.logical.sass']
 
       {tokens} = grammar.tokenizeLine '@if 1 == 1 or 2 == 2'
-      expect(tokens[9]).toEqual value: 'or', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.property-value.sass', 'keyword.operator.logical.sass']
+      expect(tokens[9]).toEqual value: 'or', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.operator.logical.sass']
 
       {tokens} = grammar.tokenizeLine '@if not 1 == 1'
-      expect(tokens[3]).toEqual value: 'not', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.property-value.sass', 'keyword.operator.logical.sass']
+      expect(tokens[3]).toEqual value: 'not', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.operator.logical.sass']
 
     it 'correctly tokenizes control operators', ->
       {tokens} = grammar.tokenizeLine '@for $i from 1 through 2'
-      expect(tokens[6]).toEqual value: 'from', scopes: ['source.sass', 'meta.at-rule.for.sass', 'meta.property-value.sass', 'keyword.operator.control.sass']
-      expect(tokens[10]).toEqual value: 'through', scopes: ['source.sass', 'meta.at-rule.for.sass', 'meta.property-value.sass', 'keyword.operator.control.sass']
+      expect(tokens[6]).toEqual value: 'from', scopes: ['source.sass', 'meta.at-rule.for.sass', 'keyword.operator.control.sass']
+      expect(tokens[10]).toEqual value: 'through', scopes: ['source.sass', 'meta.at-rule.for.sass', 'keyword.operator.control.sass']
 
       {tokens} = grammar.tokenizeLine '@for $i from 1 to 2'
-      expect(tokens[10]).toEqual value: 'to', scopes: ['source.sass', 'meta.at-rule.for.sass', 'meta.property-value.sass', 'keyword.operator.control.sass']
+      expect(tokens[10]).toEqual value: 'to', scopes: ['source.sass', 'meta.at-rule.for.sass', 'keyword.operator.control.sass']
 
       {tokens} = grammar.tokenizeLine '@each $item in $list'
-      expect(tokens[6]).toEqual value: 'in', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.property-value.sass', 'keyword.operator.control.sass']
+      expect(tokens[6]).toEqual value: 'in', scopes: ['source.sass', 'meta.at-rule.each.sass', 'keyword.operator.control.sass']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Thanks to #202, I am now painfully aware of the ambiguity caused by Sass's heavy dependence on context and the near-complete lack of Sass specs (let's test for loops...but not property lists).

This PR:
1. Removes a property-list group in a match meant for selectors (introduced in #202)
2. Updates property-list meta scopes to be consistent with all the other CSS varieties
3. Updates property-list scopes to be consistent with language-css
4. Fixes colon-first property-list syntax `:color red`
5. Ensures that property values do not overpower pseudo-classes/elements by checking for spaces after the colon
6. Adds deprecation scopes based on http://sass-lang.com/documentation/file.INDENTED_SYNTAX.html#deprecated_syntax
7. Adds some very basic regression specs

### Alternate Designs

I'll be honest, I didn't consider any going into this and quickly got tired of how tricky it was to stop various parts of the grammar from unintentionally overriding other things to reflect on any alternatives.

### Benefits

Pseudo-class/element highlighting, colon-first property-list highlighting, better meta scopes, deprecation highlighting.

### Possible Drawbacks

Anything.  The barely-existent spec coverage is nowhere near enough to catch any bugs related to this change.

### Applicable Issues

Fixes #151
https://github.com/atom/language-sass/pull/202#issuecomment-286476611

/cc @Alhadis