### PR TITLE
Tokenize placeholders in at-rules

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -62,6 +62,10 @@
   {
     'include': '#at_rule_supports'
   }
+  {
+    'match': ';'
+    'name': 'punctuation.terminator.rule.css'
+  }
 ]
 # Note how all @rules are prefixed by "at_rule_".
 'repository':
@@ -152,11 +156,11 @@
     'begin': '\\s*((@)extend\\b)\\s*'
     'captures':
       '1':
-        'name': 'keyword.control.at-rule.import.scss'
+        'name': 'keyword.control.at-rule.extend.scss'
       '2':
         'name': 'punctuation.definition.keyword.scss'
     'end': '\\s*(?=;)'
-    'name': 'meta.at-rule.import.scss'
+    'name': 'meta.at-rule.extend.scss'
     'patterns': [
       {
         'include': '#variable'
@@ -1307,7 +1311,8 @@
           | }                                # Possible end of interpolation
         )+
       )                                      # Followed by either:
-      (?= $                                  # - End of the line
+      (?= ;                                  # - End of statement
+        | $                                  # - End of the line
         | [\\s,.\\#)\\[:{>+~|]               # - Another selector
         | /\\*                               # - A block comment
       )

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -86,6 +86,13 @@ describe 'SCSS grammar', ->
         expect(tokens[10]).toEqual value: "\\@", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "constant.character.escape.scss"]
         expect(tokens[11]).toEqual value: "sm", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
 
+      it "tokenizes placeholder selectors in at-rules", ->
+        {tokens} = grammar.tokenizeLine '@extend %placeholder;'
+
+        expect(tokens[3]).toEqual value: '%', scopes: ['source.css.scss', 'meta.at-rule.extend.scss', 'entity.other.attribute-name.placeholder.css', 'punctuation.definition.entity.css']
+        expect(tokens[4]).toEqual value: 'placeholder', scopes: ['source.css.scss', 'meta.at-rule.extend.scss', 'entity.other.attribute-name.placeholder.css']
+        expect(tokens[5]).toEqual value: ';', scopes: ['source.css.scss', 'punctuation.terminator.rule.css']
+
   describe "attribute selectors", ->
     it "tokenizes them correctly", ->
       {tokens} = grammar.tokenizeLine '[something="1"]'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Placeholders can be in at-rules, in which case our ending lookahead wasn't matching when the at-rule was terminated after the placeholder.  Fix that.  Also fix `@extend` receiving import scopes.

### Alternate Designs

None.

### Benefits

Placeholders will be tokenized in at-rules.

### Possible Drawbacks

None?

### Applicable Issues

Fixes #214