### PR TITLE
Add missing pseudo-class patterns from language-css

### DIFF
--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -348,10 +348,13 @@
         'name': 'entity.name.tag.wildcard.sass'
       }
       {
+        'include': 'source.css#pseudo-classes'
+      }
+      {
         'include': 'source.css#pseudo-elements'
       }
       {
-        'include': 'source.css#pseudo-classes'
+        'include': 'source.css#functional-pseudo-classes'
       }
       {
         'captures':

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1407,6 +1407,12 @@
       {
         'include': 'source.css#pseudo-classes'
       }
+      {
+        'include': 'source.css#pseudo-elements'
+      }
+      {
+        'include': 'source.css#functional-pseudo-classes'
+      }
     ]
   # Stuff for selectors
   'selectors':

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -96,6 +96,19 @@ describe 'Sass grammar', ->
       expect(tokens[0][1]).toEqual value: '::', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css', 'punctuation.definition.entity.css']
       expect(tokens[0][2]).toEqual value: 'before', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css']
 
+    it 'tokenizes functional pseudo-classes', ->
+      tokens = grammar.tokenizeLines '''
+        &:not(.selected)
+          display: none
+      '''
+
+      expect(tokens[0][1]).toEqual value: ':', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
+      expect(tokens[0][2]).toEqual value: 'not', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
+      expect(tokens[0][3]).toEqual value: '(', scopes: ['source.sass', 'meta.selector.css', 'punctuation.section.function.begin.bracket.round.css']
+      expect(tokens[0][4]).toEqual value: '.', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.class.css', 'punctuation.definition.entity.css']
+      expect(tokens[0][5]).toEqual value: 'selected', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.class.css']
+      expect(tokens[0][6]).toEqual value: ')', scopes: ['source.sass', 'meta.selector.css', 'punctuation.section.function.end.bracket.round.css']
+
     it 'tokenizes nested pseudo-classes', ->
       tokens = grammar.tokenizeLines '''
         body

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -505,6 +505,24 @@ describe 'SCSS grammar', ->
       expect(tokens[6]).toEqual value: "}", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
       expect(tokens[7]).toEqual value: ")", scopes: ["source.css.scss", "punctuation.definition.pseudo-class.end.bracket.round.css"]
 
+  describe 'pseudo elements', ->
+    it 'inherits the matching from language-css', ->
+      {tokens} = grammar.tokenizeLine "&::after"
+
+      expect(tokens[1]).toEqual value: "::", scopes: ["source.css.scss", "entity.other.attribute-name.pseudo-element.css", "punctuation.definition.entity.css"]
+      expect(tokens[2]).toEqual value: "after", scopes: ["source.css.scss", "entity.other.attribute-name.pseudo-element.css"]
+
+  describe 'functional pseudo classes', ->
+    it 'inherits the matching from language-css', ->
+      {tokens} = grammar.tokenizeLine "&:not(.selected)"
+
+      expect(tokens[1]).toEqual value: ":", scopes: ["source.css.scss", "entity.other.attribute-name.pseudo-class.css", "punctuation.definition.entity.css"]
+      expect(tokens[2]).toEqual value: "not", scopes: ["source.css.scss", "entity.other.attribute-name.pseudo-class.css"]
+      expect(tokens[3]).toEqual value: "(", scopes: ["source.css.scss", "punctuation.section.function.begin.bracket.round.css"]
+      expect(tokens[4]).toEqual value: ".", scopes: ["source.css.scss", "entity.other.attribute-name.class.css", "punctuation.definition.entity.css"]
+      expect(tokens[5]).toEqual value: "selected", scopes: ["source.css.scss", "entity.other.attribute-name.class.css"]
+      expect(tokens[6]).toEqual value: ")", scopes: ["source.css.scss", "punctuation.section.function.end.bracket.round.css"]
+
   describe '@keyframes', ->
     it 'parses the from and to properties', ->
       tokens = grammar.tokenizeLines '''


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The SCSS rules must have been removed when inheriting from language-css, but not all the rules were inherited.

### Alternate Designs

N/A

### Benefits

Proper highlighting of pseudo-classes and elements.

### Possible Drawbacks

No interpolation support yet.

### Applicable Issues

Fixes #221