### PR TITLE
Indent after a functional pseudo-class

### DIFF
--- a/settings/language-sass.cson
+++ b/settings/language-sass.cson
@@ -8,6 +8,8 @@
         |
         [}\\w&-]+::?[#\\w&-]+ # Pseudo-elements/classes (something::before)
         |
+        [}\\w&-]+:[\\w-]+\\(.*\\) # Functional pseudo-classes (something:not(.checked))
+        |
         @(?!import|return).* # At-rule (except import and return) since some at-rules may contain colons (@media(max-width: 922px))
       )
       \\s*$ # End of line


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Noticed this while testing out #222.  Should make life a bit easier for Sass users.

### Alternate Designs

None.

### Benefits

Auto-indentation will occur when pressing enter after a functional pseudo-class.

### Possible Drawbacks

None?

### Applicable Issues

None