### PR TITLE
Improve Sass grammar

### DIFF
--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -615,7 +615,7 @@
         'name': 'keyword.operator.comparison.sass'
       }
       {
-        'match': '\\b(not\\b|or\\b|and\\b)'
+        'match': '\\b(not|or|and)\\b'
         'name': 'keyword.operator.logical.sass'
       }
     ]

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -593,7 +593,7 @@
         'beginCaptures':
           '2':
             'name': 'punctuation.definition.comment.sass'
-        'end': '(\\*/)|^(?!\\s{2}\\1)' # Include two explicit whitespace characters here because /* is two characters
+        'end': '(\\*/)|^(?!\\s\\1)' # Must be indented by at least one space
         'endCaptures':
           '1':
             'name': 'punctuation.definition.comment.sass'
@@ -604,7 +604,7 @@
         'beginCaptures':
           '2':
             'name': 'punctuation.definition.comment.sass'
-        'end': '^(?!\\s{2}\\1)' # Include two explicit whitespace characters here because // is two characters
+        'end': '^(?!\\s\\1)' # Must be indented by at least one space
         'name': 'comment.line.sass'
       }
     ]

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -451,19 +451,66 @@
     ]
   }
   {
-    'begin': '^\\s*((@)media)\\s+(((all|aural|braille|embossed|handheld|print|projection|screen|tty|tv)\\s*,?\\s*)+)\\s*{'
-    'captures':
+    'begin': '^\\s*((@)media)\\b'
+    'beginCaptures':
       '1':
         'name': 'keyword.control.at-rule.media.sass'
       '2':
         'name': 'punctuation.definition.keyword.sass'
-      '3':
-        'name': 'support.constant.media.sass'
-    'end': '\\s*((?=;|}))'
+    'end': '$'
     'name': 'meta.at-rule.media.sass'
     'patterns': [
       {
-        'include': '$self'
+        'match': '\\b(only)\\b'
+        'name': 'keyword.control.operator.css.sass'
+      }
+      {
+        'begin': '\\('
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.media-query.begin.bracket.round.sass'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.media-query.end.bracket.round.sass'
+        'name': 'meta.property-list.media-query.sass'
+        'patterns': [
+          {
+            'begin': '(?<![-a-z])(?=[-a-z])'
+            'end': '$|(?![-a-z])'
+            'name': 'meta.property-name.media-query.scss'
+            'patterns': [
+              {
+                'include': 'source.css#media-features'
+              }
+              {
+                'include': 'source.css#property-names'
+              }
+            ]
+          }
+          {
+            'begin': ':'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.separator.key-value.scss'
+            'end': '\\s*(?=\\))'
+            'contentName': 'meta.property-value.media-query.scss'
+            'patterns': [
+              {
+                'include': '#property-value'
+              }
+            ]
+          }
+        ]
+      }
+      {
+        'include': '#variable-usage'
+      }
+      {
+        'include': '#conditional-operators'
+      }
+      {
+        'include': 'source.css#media-types'
       }
     ]
   }
@@ -561,6 +608,17 @@
         'name': 'comment.line.sass'
       }
     ]
+  'conditional-operators':
+    'patterns': [
+      {
+        'match': '==|!=|<=|>=|<|>'
+        'name': 'keyword.operator.comparison.sass'
+      }
+      {
+        'match': '\\b(not\\b|or\\b|and\\b)'
+        'name': 'keyword.operator.logical.sass'
+      }
+    ]
   'property-name':
     'begin': '(?=[-A-Za-z]+)'
     'end': '(?!\\G)'
@@ -571,11 +629,6 @@
       }
     ]
   'property-value':
-    'begin': '(:)|\\G'
-    'beginCaptures':
-      '1':
-        'name': 'invalid.illegal.punctuation.sass'
-    'end': '(?=;?$)'
     'patterns': [
       {
         'include': 'source.css#numeric-values'
@@ -585,13 +638,7 @@
         'name': 'keyword.operator.css'
       }
       {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.entity.css'
-          '2':
-            'name': 'variable.other.sass'
-        'match': '(!|\\$)([a-zA-Z0-9_-]+)'
-        'name': 'meta.variable-usage.sass'
+        'include': '#variable-usage'
       }
       {
         'match': '\\b(true|false)\\b'
@@ -657,12 +704,7 @@
         'name': 'keyword.operator.control.sass'
       }
       {
-        'match': '==|!=|<=|>=|<|>'
-        'name': 'keyword.operator.comparison.sass'
-      }
-      {
-        'match': '\\b(not\\b|or\\b|and\\b)'
-        'name': 'keyword.operator.logical.sass'
+        'include': '#conditional-operators'
       }
     ]
   'string-double':
@@ -697,3 +739,11 @@
         'name': 'constant.character.escape.sass'
       }
     ]
+  'variable-usage':
+    'match': '(!|\\$)([a-zA-Z0-9_-]+)'
+    'name': 'meta.variable-usage.sass'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.entity.css'
+      '2':
+        'name': 'variable.other.sass'

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -478,7 +478,7 @@
           {
             'begin': '(?<![-a-z])(?=[-a-z])'
             'end': '$|(?![-a-z])'
-            'name': 'meta.property-name.media-query.scss'
+            'name': 'meta.property-name.media-query.sass'
             'patterns': [
               {
                 'include': 'source.css#media-features'
@@ -489,12 +489,12 @@
             ]
           }
           {
-            'begin': ':'
+            'begin': '(:)\\s*'
             'beginCaptures':
-              '0':
-                'name': 'punctuation.separator.key-value.scss'
+              '1':
+                'name': 'punctuation.separator.key-value.sass'
             'end': '\\s*(?=\\))'
-            'contentName': 'meta.property-value.media-query.scss'
+            'contentName': 'meta.property-value.media-query.sass'
             'patterns': [
               {
                 'include': '#property-value'

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -424,13 +424,13 @@
   'at_rule_media':
     'patterns': [
       {
-        'begin': '^\\s*((@)media\\b)\\s*'
-        'end': '\\s*(?={)'
-        'captures':
+        'begin': '^\\s*((@)media)\\b'
+        'beginCaptures':
           '1':
             'name': 'keyword.control.at-rule.media.scss'
           '2':
             'name': 'punctuation.definition.keyword.scss'
+        'end': '\\s*(?={)'
         'name': 'meta.at-rule.media.scss'
         'patterns': [
           {
@@ -441,7 +441,7 @@
           }
           {
             'match': '\\b(only)\\b'
-            'name': 'keyword.control.operator'
+            'name': 'keyword.control.operator.css.scss'
           }
           {
             'begin': '\\('

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -891,7 +891,7 @@
     'match': '==|!=|<=|>=|<|>'
     'name': 'keyword.operator.comparison.scss'
   'logical_operators':
-    'match': '\\b(not\\b|or\\b|and\\b)'
+    'match': '\\b(not|or|and)\\b'
     'name': 'keyword.operator.logical.scss'
   'map':
     'begin': '\\('

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -255,24 +255,28 @@ describe 'Sass grammar', ->
     it 'correctly tokenizes block comments based on indentation', ->
       tokens = grammar.tokenizeLines '''
         /* hi1
-          hi2
-        hi3
+         hi2
+          hi3
+        hi4
       '''
       expect(tokens[0][0]).toEqual value: '/*', scopes: ['source.sass', 'comment.block.sass', 'punctuation.definition.comment.sass']
       expect(tokens[0][1]).toEqual value: ' hi1', scopes: ['source.sass', 'comment.block.sass']
-      expect(tokens[1][0]).toEqual value: '  hi2', scopes: ['source.sass', 'comment.block.sass']
-      expect(tokens[2][0]).not.toEqual value: 'hi3', scopes: ['source.sass', 'comment.block.sass']
+      expect(tokens[1][0]).toEqual value: ' hi2', scopes: ['source.sass', 'comment.block.sass']
+      expect(tokens[2][0]).toEqual value: '  hi3', scopes: ['source.sass', 'comment.block.sass']
+      expect(tokens[3][0]).toEqual value: 'hi4', scopes: ['source.sass', 'meta.selector.css']
 
     it 'correctly tokenizes line comments based on indentation', ->
       tokens = grammar.tokenizeLines '''
         // hi1
-          hi2
-        hi3
+         hi2
+          hi3
+        hi4
       '''
       expect(tokens[0][0]).toEqual value: '//', scopes: ['source.sass', 'comment.line.sass', 'punctuation.definition.comment.sass']
       expect(tokens[0][1]).toEqual value: ' hi1', scopes: ['source.sass', 'comment.line.sass']
-      expect(tokens[1][0]).toEqual value: '  hi2', scopes: ['source.sass', 'comment.line.sass']
-      expect(tokens[2][0]).not.toEqual value: 'hi3', scopes: ['source.sass', 'comment.line.sass']
+      expect(tokens[1][0]).toEqual value: ' hi2', scopes: ['source.sass', 'comment.line.sass']
+      expect(tokens[2][0]).toEqual value: '  hi3', scopes: ['source.sass', 'comment.line.sass']
+      expect(tokens[3][0]).toEqual value: 'hi4', scopes: ['source.sass', 'meta.selector.css']
 
   describe 'at-rules and directives', ->
     it 'tokenizes @function', ->

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -279,6 +279,42 @@ describe 'Sass grammar', ->
       expect(tokens[3][0]).toEqual value: 'hi4', scopes: ['source.sass', 'meta.selector.css']
 
   describe 'at-rules and directives', ->
+    it 'tokenizes @media', ->
+      tokens = grammar.tokenizeLines '''
+        @media screen
+          background: none
+      '''
+
+      expect(tokens[0][0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.media.sass', 'keyword.control.at-rule.media.sass', 'punctuation.definition.keyword.sass']
+      expect(tokens[0][1]).toEqual value: 'media', scopes: ['source.sass', 'meta.at-rule.media.sass', 'keyword.control.at-rule.media.sass']
+      expect(tokens[0][2]).toEqual value: ' ', scopes: ['source.sass', 'meta.at-rule.media.sass']
+      expect(tokens[0][3]).toEqual value: 'screen', scopes: ['source.sass', 'meta.at-rule.media.sass', 'support.constant.media.css']
+      expect(tokens[1][1]).toEqual value: 'background', scopes: ['source.sass', 'meta.property-name.sass', 'support.type.property-name.css']
+
+      tokens = grammar.tokenizeLines '''
+        @media (orientation: landscape) and (min-width: 700px)
+          background: none
+      '''
+
+      expect(tokens[0][0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.media.sass', 'keyword.control.at-rule.media.sass', 'punctuation.definition.keyword.sass']
+      expect(tokens[0][1]).toEqual value: 'media', scopes: ['source.sass', 'meta.at-rule.media.sass', 'keyword.control.at-rule.media.sass']
+      expect(tokens[0][2]).toEqual value: ' ', scopes: ['source.sass', 'meta.at-rule.media.sass']
+      expect(tokens[0][3]).toEqual value: '(', scopes: ['source.sass', 'meta.at-rule.media.sass', 'meta.property-list.media-query.sass', 'punctuation.definition.media-query.begin.bracket.round.sass']
+      expect(tokens[0][4]).toEqual value: 'orientation', scopes: ['source.sass', 'meta.at-rule.media.sass', 'meta.property-list.media-query.sass', 'meta.property-name.media-query.sass', 'support.type.property-name.media.css']
+      expect(tokens[0][5]).toEqual value: ':', scopes: ['source.sass', 'meta.at-rule.media.sass', 'meta.property-list.media-query.sass', 'punctuation.separator.key-value.sass']
+      expect(tokens[0][6]).toEqual value: ' ', scopes: ['source.sass', 'meta.at-rule.media.sass', 'meta.property-list.media-query.sass']
+      expect(tokens[0][7]).toEqual value: 'landscape', scopes: ['source.sass', 'meta.at-rule.media.sass', 'meta.property-list.media-query.sass', 'meta.property-value.media-query.sass', 'support.constant.property-value.css']
+      expect(tokens[0][8]).toEqual value: ')', scopes: ['source.sass', 'meta.at-rule.media.sass', 'meta.property-list.media-query.sass', 'punctuation.definition.media-query.end.bracket.round.sass']
+      expect(tokens[0][9]).toEqual value: ' ', scopes: ['source.sass', 'meta.at-rule.media.sass']
+      expect(tokens[0][10]).toEqual value: 'and', scopes: ['source.sass', 'meta.at-rule.media.sass', 'keyword.operator.logical.sass']
+      expect(tokens[0][12]).toEqual value: '(', scopes: ['source.sass', 'meta.at-rule.media.sass', 'meta.property-list.media-query.sass', 'punctuation.definition.media-query.begin.bracket.round.sass']
+      expect(tokens[0][13]).toEqual value: 'min-width', scopes: ['source.sass', 'meta.at-rule.media.sass', 'meta.property-list.media-query.sass', 'meta.property-name.media-query.sass', 'support.type.property-name.media.css']
+      expect(tokens[0][14]).toEqual value: ':', scopes: ['source.sass', 'meta.at-rule.media.sass', 'meta.property-list.media-query.sass', 'punctuation.separator.key-value.sass']
+      expect(tokens[0][16]).toEqual value: '700', scopes: ['source.sass', 'meta.at-rule.media.sass', 'meta.property-list.media-query.sass', 'meta.property-value.media-query.sass', 'constant.numeric.css']
+      expect(tokens[0][17]).toEqual value: 'px', scopes: ['source.sass', 'meta.at-rule.media.sass', 'meta.property-list.media-query.sass', 'meta.property-value.media-query.sass', 'constant.numeric.css', 'keyword.other.unit.px.css']
+      expect(tokens[0][18]).toEqual value: ')', scopes: ['source.sass', 'meta.at-rule.media.sass', 'meta.property-list.media-query.sass', 'punctuation.definition.media-query.end.bracket.round.sass']
+      expect(tokens[1][1]).toEqual value: 'background', scopes: ['source.sass', 'meta.property-name.sass', 'support.type.property-name.css']
+
     it 'tokenizes @function', ->
       {tokens} = grammar.tokenizeLine '@function function_name($p1, $p2)'
       expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.function.sass', 'keyword.control.at-rule.function.sass', 'punctuation.definition.entity.sass']

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -595,7 +595,7 @@ describe 'SCSS grammar', ->
       expect(tokens[8]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.definition.media-query.end.bracket.round.scss']
       expect(tokens[9]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.at-rule.media.scss']
       expect(tokens[10]).toEqual value: 'and', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.operator.logical.scss']
-      expect(tokens[12]).toEqual value: 'only', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.control.operator']
+      expect(tokens[12]).toEqual value: 'only', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.control.operator.css.scss']
       expect(tokens[14]).toEqual value: 'screen', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'support.constant.media.css']
       expect(tokens[16]).toEqual value: 'and', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.operator.logical.scss']
       expect(tokens[18]).toEqual value: '(', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.definition.media-query.begin.bracket.round.scss']

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -582,7 +582,16 @@ describe 'SCSS grammar', ->
 
   describe 'media queries', ->
     it 'parses media types and features', ->
-      {tokens} = grammar.tokenizeLine '@media (orientation: landscape) and only screen and (min-width: 700px) /* comment */ {}'
+      {tokens} = grammar.tokenizeLine '@media screen {}'
+
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.control.at-rule.media.scss', 'punctuation.definition.keyword.scss']
+      expect(tokens[1]).toEqual value: 'media', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.control.at-rule.media.scss']
+      expect(tokens[2]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.at-rule.media.scss']
+      expect(tokens[3]).toEqual value: 'screen', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'support.constant.media.css']
+      expect(tokens[4]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.at-rule.media.scss']
+      expect(tokens[5]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
+
+      {tokens} = grammar.tokenizeLine '@media (orientation: landscape) and (min-width: 700px) /* comment */ {}'
 
       expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.control.at-rule.media.scss', 'punctuation.definition.keyword.scss']
       expect(tokens[1]).toEqual value: 'media', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.control.at-rule.media.scss']
@@ -595,17 +604,14 @@ describe 'SCSS grammar', ->
       expect(tokens[8]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.definition.media-query.end.bracket.round.scss']
       expect(tokens[9]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.at-rule.media.scss']
       expect(tokens[10]).toEqual value: 'and', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.operator.logical.scss']
-      expect(tokens[12]).toEqual value: 'only', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.control.operator.css.scss']
-      expect(tokens[14]).toEqual value: 'screen', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'support.constant.media.css']
-      expect(tokens[16]).toEqual value: 'and', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'keyword.operator.logical.scss']
-      expect(tokens[18]).toEqual value: '(', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.definition.media-query.begin.bracket.round.scss']
-      expect(tokens[19]).toEqual value: 'min-width', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'meta.property-name.media-query.scss', 'support.type.property-name.media.css']
-      expect(tokens[20]).toEqual value: ':', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.separator.key-value.scss']
-      expect(tokens[22]).toEqual value: '700', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'meta.property-value.media-query.scss', 'constant.numeric.css']
-      expect(tokens[23]).toEqual value: 'px', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'meta.property-value.media-query.scss', 'constant.numeric.css', 'keyword.other.unit.px.css']
-      expect(tokens[24]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.definition.media-query.end.bracket.round.scss']
-      expect(tokens[26]).toEqual value: '/*', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'comment.block.scss', 'punctuation.definition.comment.scss']
-      expect(tokens[30]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
+      expect(tokens[12]).toEqual value: '(', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.definition.media-query.begin.bracket.round.scss']
+      expect(tokens[13]).toEqual value: 'min-width', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'meta.property-name.media-query.scss', 'support.type.property-name.media.css']
+      expect(tokens[14]).toEqual value: ':', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.separator.key-value.scss']
+      expect(tokens[16]).toEqual value: '700', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'meta.property-value.media-query.scss', 'constant.numeric.css']
+      expect(tokens[17]).toEqual value: 'px', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'meta.property-value.media-query.scss', 'constant.numeric.css', 'keyword.other.unit.px.css']
+      expect(tokens[18]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'meta.property-list.media-query.scss', 'punctuation.definition.media-query.end.bracket.round.scss']
+      expect(tokens[20]).toEqual value: '/*', scopes: ['source.css.scss', 'meta.at-rule.media.scss', 'comment.block.scss', 'punctuation.definition.comment.scss']
+      expect(tokens[24]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
 
   describe 'functions', ->
     it 'parses them', ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Sass:
* Fixed `@media`
* Only require one space for indented comments

### Alternate Designs

N/A

### Benefits

See above

### Possible Drawbacks

None

### Applicable Issues

Part of #165