### PR TITLE
Support interpolation in custom selectors

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -18,13 +18,13 @@
     'include': '#at_rule_import'
   }
   {
+    'include': '#rules'
+  }
+  {
     'include': '#general'
   }
   {
     'include': '#flow_control'
-  }
-  {
-    'include': '#rules'
   }
   {
     'include': '#property_list'
@@ -1093,9 +1093,6 @@
   'rules':
     'patterns': [
       {
-        'include': '#general'
-      }
-      {
         'include': '#at_rule_extend'
       }
       {
@@ -1109,6 +1106,9 @@
       }
       {
         'include': '#selectors'
+      }
+      {
+        'include': '#general'
       }
     ]
   'selector_attribute':
@@ -1263,8 +1263,35 @@
           }
         ]
   'selector_custom':
-    'match': '\\b([a-zA-Z0-9]+(-[a-zA-Z0-9]+)+)(?=\\.|\\s++[^:]|\\s*[,\\[{]|:(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|nth-(child|last-child|of-type|last-of-type)|first-child|last-child|first-of-type|last-of-type|only-child|only-of-type|empty|not|valid|invalid)(\\([0-9A-Za-z]*\\))?)'
-    'name': 'entity.name.tag.custom.scss'
+    'match': '''(?x) (?<![@\\w-])
+      ([a-z]|\\#\\{) # Custom element names must start with a lowercase letter or interpolation
+      (
+        [\\w&-]      # Allow any word character, &, or dash
+        | \\#\\{     # Interpolation (escaped to avoid Coffeelint errors)
+        | \\$        # Possible start of interpolation variable
+        | }          # Possible end of interpolation
+      )+
+      (?=            # Followed by one of:
+        [.\\#\\[]    # Start of class, id, or attribute selector
+        | \\s*[,{]   # Start of another selector or property-list
+        | \\s++[^:]  # Whitespace followed by anything but :
+        | :(link|visited|hover|active|focus|target|lang|disabled|enabled|checked|indeterminate|root|
+            nth-(child|last-child|of-type|last-of-type)|first-child|last-child|first-of-type|
+            last-of-type|only-child|only-of-type|empty|not|valid|invalid)
+          (\\([0-9A-Za-z]*\\))?) # pseudo-class/element
+    '''
+    'name': 'entity.name.tag.custom.css'
+    'captures':
+      '0':
+        'patterns': [
+          {
+            'include': '#interpolation'
+          }
+          {
+            'match': '[A-Z]'
+            'name': 'invalid.illegal.identifier.css'
+          }
+        ]
   'selector_id':
     'match': '''(?x)
       (\\#)                                  # Valid id-name

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -309,7 +309,7 @@ describe 'SCSS grammar', ->
       {tokens} = grammar.tokenizeLine 'very-custom { very-very-custom { color: inherit; } margin: top; }'
 
       expect(tokens[2]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
-      expect(tokens[4]).toEqual value: 'very-very-custom', scopes: ['source.css.scss', 'meta.property-list.scss', 'entity.name.tag.custom.scss']
+      expect(tokens[4]).toEqual value: 'very-very-custom', scopes: ['source.css.scss', 'meta.property-list.scss', 'entity.name.tag.custom.css']
       expect(tokens[6]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
       expect(tokens[8]).toEqual value: 'color', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[11]).toEqual value: 'inherit', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
@@ -332,11 +332,11 @@ describe 'SCSS grammar', ->
         another-one { display: none; }
       '''
 
-      expect(tokens[0][0]).toEqual value: 'very-custom', scopes: ['source.css.scss', 'entity.name.tag.custom.scss']
+      expect(tokens[0][0]).toEqual value: 'very-custom', scopes: ['source.css.scss', 'entity.name.tag.custom.css']
       expect(tokens[0][4]).toEqual value: 'color', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[0][7]).toEqual value: 'inherit', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
       expect(tokens[0][9]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.end.bracket.curly.scss']
-      expect(tokens[1][0]).toEqual value: 'another-one', scopes: ['source.css.scss', 'entity.name.tag.custom.scss']
+      expect(tokens[1][0]).toEqual value: 'another-one', scopes: ['source.css.scss', 'entity.name.tag.custom.css']
       expect(tokens[1][10]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.end.bracket.curly.scss']
 
     describe 'property values', ->
@@ -398,30 +398,30 @@ describe 'SCSS grammar', ->
     it 'tokenizes them as tags', ->
       {tokens} = grammar.tokenizeLine 'very-custom { color: red; }'
 
-      expect(tokens[0]).toEqual value: 'very-custom', scopes: ['source.css.scss', 'entity.name.tag.custom.scss']
+      expect(tokens[0]).toEqual value: 'very-custom', scopes: ['source.css.scss', 'entity.name.tag.custom.css']
 
       {tokens} = grammar.tokenizeLine 'very-very-custom { color: red; }'
 
-      expect(tokens[0]).toEqual value: 'very-very-custom', scopes: ['source.css.scss', 'entity.name.tag.custom.scss']
+      expect(tokens[0]).toEqual value: 'very-very-custom', scopes: ['source.css.scss', 'entity.name.tag.custom.css']
 
     it 'tokenizes them with pseudo selectors', ->
       {tokens} = grammar.tokenizeLine 'very-custom:hover { color: red; }'
 
-      expect(tokens[0]).toEqual value: 'very-custom', scopes: ['source.css.scss', 'entity.name.tag.custom.scss']
+      expect(tokens[0]).toEqual value: 'very-custom', scopes: ['source.css.scss', 'entity.name.tag.custom.css']
       expect(tokens[1]).toEqual value: ':', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
       expect(tokens[2]).toEqual value: 'hover', scopes: ['source.css.scss', 'entity.other.attribute-name.pseudo-class.css']
 
     it 'tokenizes them with class selectors', ->
       {tokens} = grammar.tokenizeLine 'very-custom.class { color: red; }'
 
-      expect(tokens[0]).toEqual value: 'very-custom', scopes: ['source.css.scss', 'entity.name.tag.custom.scss']
+      expect(tokens[0]).toEqual value: 'very-custom', scopes: ['source.css.scss', 'entity.name.tag.custom.css']
       expect(tokens[1]).toEqual value: '.', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'punctuation.definition.entity.css']
       expect(tokens[2]).toEqual value: 'class', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css']
 
     it "tokenizes them with attribute selectors", ->
       {tokens} = grammar.tokenizeLine "md-toolbar[color='primary']"
 
-      expect(tokens[0]).toEqual value: "md-toolbar", scopes: ["source.css.scss", "entity.name.tag.custom.scss"]
+      expect(tokens[0]).toEqual value: "md-toolbar", scopes: ["source.css.scss", "entity.name.tag.custom.css"]
       expect(tokens[1]).toEqual value: "[", scopes: ["source.css.scss", "meta.attribute-selector.scss", "punctuation.definition.attribute-selector.begin.bracket.square.scss"]
       expect(tokens[2]).toEqual value: "color", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss"]
       expect(tokens[3]).toEqual value: "=", scopes: ["source.css.scss", "meta.attribute-selector.scss", "keyword.operator.scss"]
@@ -429,6 +429,14 @@ describe 'SCSS grammar', ->
       expect(tokens[5]).toEqual value: "primary", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.quoted.single.attribute-value.scss"]
       expect(tokens[6]).toEqual value: "'", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.quoted.single.attribute-value.scss", "punctuation.definition.string.end.scss"]
       expect(tokens[7]).toEqual value: ']', scopes: ["source.css.scss", "meta.attribute-selector.scss", "punctuation.definition.attribute-selector.end.bracket.square.scss"]
+
+    it "tokenizes them with interpolation", ->
+      {tokens} = grammar.tokenizeLine "#\{&}__foo { color: red }"
+
+      expect(tokens[0]).toEqual value: "#\{", scopes: ["source.css.scss", "entity.name.tag.custom.css", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
+      expect(tokens[1]).toEqual value: "&", scopes: ["source.css.scss", "entity.name.tag.custom.css", "variable.interpolation.scss"]
+      expect(tokens[2]).toEqual value: "}", scopes: ["source.css.scss", "entity.name.tag.custom.css", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
+      expect(tokens[3]).toEqual value: "__foo", scopes: ["source.css.scss", "entity.name.tag.custom.css"]
 
     it 'does not confuse them with properties', ->
       tokens = grammar.tokenizeLines '''


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Adds support for interpolation in custom selectors.

### Alternate Designs

None.

### Benefits

See above.

### Possible Drawbacks

This necessitated the switching of `#rules` and `#general` in priority.  Hopefully that shouldn't break anything.

### Applicable Issues

Fixes #208