### PR TITLE
Tokenize $= selector

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1122,7 +1122,7 @@
           | \\#\\{                           # Interpolation (escaped to avoid Coffeelint errors)
           | \\$                              # Possible start of interpolation variable
           | }                                # Possible end of interpolation
-        )+
+        )+?
       )
       (?:
         \\s*([~|^$*]?=)\\s*

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -121,6 +121,15 @@ describe 'SCSS grammar', ->
       expect(tokens[10]).toEqual value: "e", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.unquoted.attribute-value.scss"]
       expect(tokens[11]).toEqual value: "]", scopes: ["source.css.scss", "meta.attribute-selector.scss", "punctuation.definition.attribute-selector.end.bracket.square.scss"]
 
+    it "tokenizes the $= selector", ->
+      {tokens} = grammar.tokenizeLine "[class$=test]"
+
+      expect(tokens[0]).toEqual value: "[", scopes: ["source.css.scss", "meta.attribute-selector.scss", "punctuation.definition.attribute-selector.begin.bracket.square.scss"]
+      expect(tokens[1]).toEqual value: "class", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss"]
+      expect(tokens[2]).toEqual value: "$=", scopes: ["source.css.scss", "meta.attribute-selector.scss", "keyword.operator.scss"]
+      expect(tokens[3]).toEqual value: "test", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.unquoted.attribute-value.scss"]
+      expect(tokens[4]).toEqual value: "]", scopes: ["source.css.scss", "meta.attribute-selector.scss", "punctuation.definition.attribute-selector.end.bracket.square.scss"]
+
     it "tokenizes multiple attribute selectors", ->
       {tokens} = grammar.tokenizeLine '[data-name="text-color"][data-value="null"]'
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Not my ideal solution, but it's simple, unlikely to regress, and it works.

### Alternate Designs

Non-trivial rewrite of how interpolation is supported in selectors.

### Benefits

`[...$=...]` will work.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #231