### PR TITLE
fix broken highlighting for properties sharing selector names

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -27,6 +27,9 @@
     'include': '#rules'
   }
   {
+    'include': '#selectors'
+  }
+  {
     'include': '#property_list'
   }
   {
@@ -416,6 +419,9 @@
             }
             {
               'include': '#rules'
+            }
+            {
+              'include': "#selectors"
             }
           ]
         }
@@ -973,7 +979,7 @@
   'properties':
     'patterns': [
       {
-        'begin': '(?<![-a-z])(?=[-a-z])'
+        'begin': '(?<![-a-z])(?!--)(?=[-a-z])'
         'end': '$|(?![-a-z])'
         'name': 'meta.property-name.scss'
         'patterns': [
@@ -1020,10 +1026,16 @@
         'include': '#flow_control'
       }
       {
+        'include': '#rules'
+      }
+      {
+        'include': '#selector_custom'
+      }
+      {
         'include': '#properties'
       }
       {
-        'include': '#rules'
+        'include': 'selectors'
       }
       {
         'include': '$self'
@@ -1106,9 +1118,6 @@
       }
       {
         'include': '#at_rule_media'
-      }
-      {
-        'include': '#selectors'
       }
     ]
   'selector_attribute':

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1020,10 +1020,10 @@
         'include': '#flow_control'
       }
       {
-        'include': '#rules'
+        'include': '#properties'
       }
       {
-        'include': '#properties'
+        'include': '#rules'
       }
       {
         'include': '$self'

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -396,6 +396,28 @@ describe 'SCSS grammar', ->
       expect(tokens[1][3]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss']
       expect(tokens[1][4]).toEqual value: 'fixed', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
 
+  describe 'property names that match element names', ->
+    it 'does not confuse them with properties', ->
+      tokens = grammar.tokenizeLines '''
+        content {
+          content: 'foo';
+        }
+      '''
+
+      expect(tokens[0][0]).toEqual value: 'content', scopes: ['source.css.scss', 'entity.name.tag.css']
+      expect(tokens[0][1]).toEqual value: ' ', scopes: ['source.css.scss']
+      expect(tokens[0][2]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
+      expect(tokens[1][0]).toEqual value: '  ', scopes: ['source.css.scss', 'meta.property-list.scss']
+      expect(tokens[1][1]).toEqual value: 'content', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
+      expect(tokens[1][2]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.separator.key-value.scss']
+      expect(tokens[1][3]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss']
+      expect(tokens[1][4]).toEqual value: '\'', scopes : ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'punctuation.definition.string.begin.scss']
+      expect(tokens[1][5]).toEqual value: 'foo', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss']
+      expect(tokens[1][6]).toEqual value: '\'', scopes : ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'punctuation.definition.string.end.scss']
+      expect(tokens[1][7]).toEqual value: ';', scopes : ['source.css.scss', 'meta.property-list.scss',  'punctuation.terminator.rule.scss']
+      expect(tokens[1][7]).toEqual value: ';', scopes : ['source.css.scss', 'meta.property-list.scss',  'punctuation.terminator.rule.scss']
+      expect(tokens[2][0]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.end.bracket.curly.scss']
+
   describe 'vendor properties', ->
     it 'tokenizes the browser prefix', ->
       {tokens} = grammar.tokenizeLine 'body { -webkit-box-shadow: none; }'

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -411,11 +411,11 @@ describe 'SCSS grammar', ->
       expect(tokens[1][1]).toEqual value: 'content', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-name.scss', 'support.type.property-name.css']
       expect(tokens[1][2]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[1][3]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.property-list.scss']
-      expect(tokens[1][4]).toEqual value: '\'', scopes : ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'punctuation.definition.string.begin.scss']
+      expect(tokens[1][4]).toEqual value: '\'', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'punctuation.definition.string.begin.scss']
       expect(tokens[1][5]).toEqual value: 'foo', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss']
-      expect(tokens[1][6]).toEqual value: '\'', scopes : ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'punctuation.definition.string.end.scss']
-      expect(tokens[1][7]).toEqual value: ';', scopes : ['source.css.scss', 'meta.property-list.scss',  'punctuation.terminator.rule.scss']
-      expect(tokens[1][7]).toEqual value: ';', scopes : ['source.css.scss', 'meta.property-list.scss',  'punctuation.terminator.rule.scss']
+      expect(tokens[1][6]).toEqual value: '\'', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'punctuation.definition.string.end.scss']
+      expect(tokens[1][7]).toEqual value: ';', scopes: ['source.css.scss', 'meta.property-list.scss',  'punctuation.terminator.rule.scss']
+      expect(tokens[1][7]).toEqual value: ';', scopes: ['source.css.scss', 'meta.property-list.scss',  'punctuation.terminator.rule.scss']
       expect(tokens[2][0]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.end.bracket.curly.scss']
 
   describe 'vendor properties', ->

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -369,7 +369,7 @@ describe 'SCSS grammar', ->
         expect(tokens[32]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
 
   describe 'property names with a prefix that matches an element name', ->
-    it 'does not confuse them with properties', ->
+    it 'does not confuse them with selectors', ->
       tokens = grammar.tokenizeLines '''
         text {
           text-align: center;
@@ -397,7 +397,7 @@ describe 'SCSS grammar', ->
       expect(tokens[1][4]).toEqual value: 'fixed', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.constant.property-value.css']
 
   describe 'property names that match element names', ->
-    it 'does not confuse them with properties', ->
+    it 'does not confuse them with selectors', ->
       tokens = grammar.tokenizeLines '''
         content {
           content: 'foo';


### PR DESCRIPTION
Hi there,

This PR addresses a small issue in the scss grammar that caused property names that match selector names to be highlighted incorrectly.

The fix simply involved switching the order of the includes.

The bug can be reproduced using the current grammar by typing this into a scss file...

```scss
.foo {
  color: red; // no issue
  font: 'Helvetica'; // issue
  cursor: pointer; // issue
  content: ''; // issue
}
```

Let me know if you need anything else. Thanks so much :smile:

**Edit:**

Fixes #226