### PR TITLE
Remove duplicate .source.sass snippet selector

### DIFF
--- a/snippets/language-sass.cson
+++ b/snippets/language-sass.cson
@@ -2,7 +2,6 @@
   '!important':
     'prefix': '!'
     'body': '!important${1:;}$0'
-'.source.sass':
   '@import':
     'prefix': 'import'
     'body': '@import "$0"'


### PR DESCRIPTION
Allows the `!important` snippet to show up.