### PR TITLE
Fix incorrect tokenization of SCSS class extensions

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1546,5 +1546,5 @@
       }
     ]
   'variables':
-    'match': '(\\$|\\-\\-)[A-Za-z0-9_-]+\\b'
+    'match': '(\\$|(?<!&)\\-\\-)[A-Za-z0-9_-]+\\b'
     'name': 'variable.scss'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR prevents extended SCSS class names with 2 or more hyphens after the name break from being tokenized as variables. Consider the following code snippet:

```
.block {
   &__element {}
   &--modifier {}
   &.another-block {}
   &-wrapper {}
}
```

`__element`, `.another-block` and `-wrapper` are all tokenized as `punctuation.definition.entity.css`.

`--modifier` is incorrectly tokenized as `variable.scss`.

### Alternate Designs

None.

### Benefits

Proper token colorization.

### Possible Drawbacks

None that I can foresee.

### Applicable Issues

#241
