### PR TITLE
adds - as nonWordCharacter / word separator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-sass",
-  "version": "0.61.4",
+  "version": "0.61.5",
   "description": "Sass/SCSS language support in Atom",
   "license": "MIT",
   "engines": {

--- a/settings/language-sass.cson
+++ b/settings/language-sass.cson
@@ -22,7 +22,7 @@
 
 '.source.sass, .source.css.scss':
   'editor':
-    'nonWordCharacters': '/\\()"\':,.;<>~!#%^&*|+=[]{}`?…'
+    'nonWordCharacters': '/\\()"\':,.;<>~!#%^&*|+=[]{}`?…-'
     'commentStart': '// '
   'autocomplete':
     'symbols':


### PR DESCRIPTION
### Description of the Change

adds `-` as nonWordCharacter (a.k.a. word separator)

### Benefits

Enables quick keyboard navigation _within_ sass variable names/selectors, etc (i.e. sass-variable-name)