### PR TITLE
🎁 Add SassDoc grammar patterns

### DIFF
--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -589,6 +589,19 @@
             'name': 'invalid.illegal.sass'
       }
       {
+        'name': 'comment.block.documentation.sass'
+        'begin': '^(\\s*)(///)'
+        'beginCaptures':
+          '2':
+            'name': 'punctuation.definition.comment.sass'
+        'end': '^(?!\\s\\1)' # Must be indented by at least one space
+        'patterns': [
+          {
+            'include': 'source.sassdoc'
+          }
+        ]
+      }
+      {
         'begin': '^(\\s*)(/\\*)'
         'beginCaptures':
           '2':

--- a/grammars/sassdoc.cson
+++ b/grammars/sassdoc.cson
@@ -266,7 +266,7 @@
     'begin': '''(?x)
       (
         (@)
-        (?:returns?|throws?|exception|type|outputs?)
+        (?:returns?|throws?|exception|outputs?)
       )
       \\s+(?={)
     '''
@@ -281,6 +281,34 @@
         'include': '#sassdoctype'
       }
     ]
+  }
+  {
+    # Type annotation blocks
+    # -  @type type|othertype
+    'match': '''(?x)
+      (
+        (@)
+        (?:type)
+      )
+      \\s+
+      (
+        (?:
+          [A-Za-z |]+
+        )
+      )
+    '''
+    'captures':
+      '1':
+        'name': 'storage.type.class.sassdoc'
+      '2':
+        'name': 'punctuation.definition.block.tag.sassdoc'
+      '3':
+        'name': 'entity.name.type.instance.sassdoc'
+        'patterns': [
+          {
+            'include': '#sassdoctypedelimiter'
+          }
+        ]
   }
   {
     # Tags followed by a namepath
@@ -306,7 +334,7 @@
         'name': 'entity.name.type.instance.sassdoc'
   }
   {
-    'name': 'storage.type.class.sassdoc',
+    'name': 'storage.type.class.sassdoc'
     'match': '''(?x)
       (@)
       (?:access|alias|author|content|deprecated|example|exception|group
@@ -343,6 +371,12 @@
         ]
       }
     ]
+
+  'sassdoctypedelimiter':
+    'match': '(\\|)'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.delimiter.sassdoc'
 
   # {type}
   'sassdoctype':

--- a/grammars/sassdoc.cson
+++ b/grammars/sassdoc.cson
@@ -49,37 +49,93 @@
   }
   {
     # @example text();
-    'name': 'meta.example.sassdoc'
-    'begin': '((@)example)\\s+'
+    'name': 'meta.example.css.scss.sassdoc'
+    'begin': '''(?x)
+      ((@)example)
+      \\s+
+      (css|scss)
+    '''
     'end': '(?=@|///$)'
     'beginCaptures':
       '1':
         'name': 'storage.type.class.sassdoc'
       '2':
         'name': 'punctuation.definition.block.tag.sassdoc'
+      '3':
+        'name': 'variable.other.sassdoc'
     'patterns': [
       {
         'match': '^///\\s+'
       }
       {
-        # Leading <caption>…</caption> before example
-        'contentName': 'constant.other.description.sassdoc'
-        'begin': '\\G(<)caption(>)'
-        'beginCaptures':
+        # Highlighted (S)CSS example
+        'match': '[^\\s@*](?:[^*]|\\*[^/])*'
+        'captures':
           '0':
-            'name': 'entity.name.tag.inline.sassdoc'
-          '1':
-            'name': 'punctuation.definition.bracket.angle.begin.sassdoc'
-          '2':
-            'name': 'punctuation.definition.bracket.angle.end.sassdoc'
-        'end': '(</)caption(>)|(?=///$)'
-        'endCaptures':
+            'name': 'source.embedded.css.scss'
+            'patterns': [
+              {
+                'include': 'source.css.scss'
+              }
+            ]
+      }
+    ]
+  }
+  {
+    # @example Markup
+    # There must be a better way to do this.
+    'name': 'meta.example.html.sassdoc'
+    'begin': '''(?x)
+      ((@)example)
+      \\s+
+      (markup)
+    '''
+    'end': '(?=@|///$)'
+    'beginCaptures':
+      '1':
+        'name': 'storage.type.class.sassdoc'
+      '2':
+        'name': 'punctuation.definition.block.tag.sassdoc'
+      '3':
+        'name': 'variable.other.sassdoc'
+    'patterns': [
+      {
+        'match': '^///\\s+'
+      }
+      {
+        # Highlighted markup example
+        'match': '[^\\s@*](?:[^*]|\\*[^/])*'
+        'captures':
           '0':
-            'name': 'entity.name.tag.inline.sassdoc'
-          '1':
-            'name': 'punctuation.definition.bracket.angle.begin.sassdoc'
-          '2':
-            'name': 'punctuation.definition.bracket.angle.end.sassdoc'
+            'name': 'source.embedded.html'
+            'patterns': [
+              {
+                'include': 'source.html'
+              }
+            ]
+      }
+    ]
+  }
+  {
+    # @example JavaScript
+    # Again, hopefully a better way can be found.
+    'name': 'meta.example.js.sassdoc'
+    'begin': '''(?x)
+      ((@)example)
+      \\s+
+      (javascript)
+    '''
+    'end': '(?=@|///$)'
+    'beginCaptures':
+      '1':
+        'name': 'storage.type.class.sassdoc'
+      '2':
+        'name': 'punctuation.definition.block.tag.sassdoc'
+      '3':
+        'name': 'variable.other.sassdoc'
+    'patterns': [
+      {
+        'match': '^///\\s+'
       }
       {
         # Highlighted JavaScript example
@@ -94,7 +150,7 @@
             ]
       }
     ]
-  },
+  }
   {
     # @see namepathOrURL
     'match': '''(?x)

--- a/grammars/sassdoc.cson
+++ b/grammars/sassdoc.cson
@@ -152,6 +152,29 @@
     ]
   }
   {
+    # @link URL [Caption]
+    'match': '''(?x)
+      ((@)link)
+      \\s+
+      (?:
+        # URL
+        (
+          (?=https?://)
+          (?:[^\\s*]|\\*[^/])+
+        )
+      )
+    '''
+    'captures':
+      '1':
+        'name': 'storage.type.class.sassdoc'
+      '2':
+        'name': 'punctuation.definition.block.tag.sassdoc'
+      '3':
+        'name': 'variable.other.link.underline.sassdoc'
+      '4':
+        'name': 'entity.name.type.instance.sassdoc'
+  }
+  {
     # @see namepathOrURL
     'match': '''(?x)
       ((@)see)

--- a/grammars/sassdoc.cson
+++ b/grammars/sassdoc.cson
@@ -250,9 +250,6 @@
             'name': 'source.embedded.js'
             'patterns': [
               {
-                'include': '#inline-tags'
-              }
-              {
                 'include': 'source.js'
               }
             ]
@@ -321,9 +318,6 @@
       '1':
         'name': 'punctuation.definition.block.tag.sassdoc'
   }
-  {
-    'include': '#inline-tags'
-  }
 ]
 
 'repository':
@@ -345,54 +339,6 @@
         'patterns': [
           {
             'include': '#brackets'
-          }
-        ]
-      }
-    ]
-
-  'inline-tags':
-    'patterns': [
-      {
-        # Description preceding {@inline tag}
-        'captures':
-          '1':
-            'name': 'punctuation.definition.bracket.square.begin.sassdoc'
-          '2':
-            'name': 'punctuation.definition.bracket.square.end.sassdoc'
-        'match': '(\\[)[^\\]]+(\\])(?={@(?:link))'
-        'name': 'constant.other.description.sassdoc'
-      }
-      {
-        # {@link …}
-        'begin': '({)((@)(?:link))\\s*'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.definition.bracket.curly.begin.sassdoc'
-          '2':
-            'name': 'storage.type.class.sassdoc'
-          '3':
-            'name': 'punctuation.definition.inline.tag.sassdoc'
-        'end': '}|(?=$)'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.bracket.curly.end.sassdoc'
-        'name': 'entity.name.type.instance.sassdoc'
-        'patterns': [
-          {
-            'captures':
-              '1':
-                'name': 'variable.other.link.underline.sassdoc'
-              '2':
-                'name': 'punctuation.separator.pipe.sassdoc'
-            'match': '\\G((?=https?://)(?:[^|}\\s*]|\\*[/])+)(\\|)?'
-          }
-          {
-            'captures':
-              '1':
-                'name': 'variable.other.description.sassdoc'
-              '2':
-                'name': 'punctuation.separator.pipe.sassdoc'
-            'match': '\\G((?:[^{}@\\s|*]|\\*[^/])+)(\\|)?'
           }
         ]
       }

--- a/grammars/sassdoc.cson
+++ b/grammars/sassdoc.cson
@@ -1,0 +1,387 @@
+'scopeName': 'source.sassdoc'
+'name': 'SassDoc'
+'patterns': [
+  {
+    # @access private|public
+    'match': '''(?x)
+      ((@)(?:access))
+      \\s+
+      (private|public)
+      \\b
+    '''
+    'captures':
+      '1':
+        'name': 'storage.type.class.sassdoc'
+      '2':
+        'name': 'punctuation.definition.block.tag.sassdoc'
+      '3':
+        'name': 'constant.language.access-type.sassdoc'
+  }
+  {
+    # @author name [<email>]
+    'match': '''(?x)
+      ((@)author)
+      \\s+
+      (
+        [^@\\s<>*/]
+        (?:[^@<>*/]|\\*[^/])*
+      )
+      (?:
+        \\s*
+        (<)
+        ([^>\\s]+)
+        (>)
+      )?
+    '''
+    'captures':
+      '1':
+        'name': 'storage.type.class.sassdoc'
+      '2':
+        'name': 'punctuation.definition.block.tag.sassdoc'
+      '3':
+        'name': 'entity.name.type.instance.sassdoc'
+      '4':
+        'name': 'punctuation.definition.bracket.angle.begin.sassdoc'
+      '5':
+        'name': 'constant.other.email.link.underline.sassdoc'
+      '6':
+        'name': 'punctuation.definition.bracket.angle.end.sassdoc'
+  }
+  {
+    # @example text();
+    'name': 'meta.example.sassdoc'
+    'begin': '((@)example)\\s+'
+    'end': '(?=@|///$)'
+    'beginCaptures':
+      '1':
+        'name': 'storage.type.class.sassdoc'
+      '2':
+        'name': 'punctuation.definition.block.tag.sassdoc'
+    'patterns': [
+      {
+        'match': '^///\\s+'
+      }
+      {
+        # Leading <caption>…</caption> before example
+        'contentName': 'constant.other.description.sassdoc'
+        'begin': '\\G(<)caption(>)'
+        'beginCaptures':
+          '0':
+            'name': 'entity.name.tag.inline.sassdoc'
+          '1':
+            'name': 'punctuation.definition.bracket.angle.begin.sassdoc'
+          '2':
+            'name': 'punctuation.definition.bracket.angle.end.sassdoc'
+        'end': '(</)caption(>)|(?=///$)'
+        'endCaptures':
+          '0':
+            'name': 'entity.name.tag.inline.sassdoc'
+          '1':
+            'name': 'punctuation.definition.bracket.angle.begin.sassdoc'
+          '2':
+            'name': 'punctuation.definition.bracket.angle.end.sassdoc'
+      }
+      {
+        # Highlighted JavaScript example
+        'match': '[^\\s@*](?:[^*]|\\*[^/])*'
+        'captures':
+          '0':
+            'name': 'source.embedded.js'
+            'patterns': [
+              {
+                'include': 'source.js'
+              }
+            ]
+      }
+    ]
+  },
+  {
+    # @see namepathOrURL
+    'match': '''(?x)
+      ((@)see)
+      \\s+
+      (?:
+        # URL
+        (
+          (?=https?://)
+          (?:[^\\s*]|\\*[^/])+
+        )
+        |
+        # JSDoc namepath
+        (
+          (?!
+            # Avoid matching bare URIs (also acceptable as links)
+            https?://
+            |
+            # Avoid matching {@inline tags}; we match those below
+            (?:\\[[^\\[\\]]*\\])? # Possible description [preceding]{@tag}
+            {@(?:link|linkcode|linkplain|tutorial)\\b
+          )
+          # Matched namepath
+          (?:[^@\\s*/]|\\*[^/])+
+        )
+      )
+    '''
+    'captures':
+      '1':
+        'name': 'storage.type.class.sassdoc'
+      '2':
+        'name': 'punctuation.definition.block.tag.sassdoc'
+      '3':
+        'name': 'variable.other.link.underline.sassdoc'
+      '4':
+        'name': 'entity.name.type.instance.sassdoc'
+  }
+  {
+    # Tags followed by an identifier token
+    # - @<tag> identifier
+    'match': '''(?x)
+      (
+        (@)
+        (?:arg|argument|param|parameter)
+      )
+      \\s+
+      (
+        [A-Za-z_$]
+        [\\w$.\\[\\]]*
+      )
+    '''
+    'captures':
+      '1':
+        'name': 'storage.type.class.sassdoc'
+      '2':
+        'name': 'punctuation.definition.block.tag.sassdoc'
+      '3':
+        'name': 'variable.other.sassdoc'
+  }
+  {
+    # Tags followed by a type expression, then an identifier
+    # -  @<tag> {type} identifier
+    'begin': '((@)(?:arg|argument|param|parameter|prop|property))\\s+(?={)'
+    'beginCaptures':
+      '1':
+        'name': 'storage.type.class.sassdoc'
+      '2':
+        'name': 'punctuation.definition.block.tag.sassdoc'
+    'end': '(?=\\s|\\*/|[^{}\\[\\]A-Za-z_$])'
+    'patterns': [
+      {
+        'include': '#sassdoctype'
+      }
+      {
+        'match': '([A-Za-z_$][\\w$.\\[\\]]*)'
+        'name': 'variable.other.sassdoc'
+      }
+      {
+        # Optional value
+        'name': 'variable.other.sassdoc'
+        'match': '''(?x)
+          (\\[)\\s*
+          [\\w$]+
+          (?:
+            (?:\\[\\])?                                        # Foo[].bar properties within an array
+            \\.                                                # Foo.Bar namespaced parameter
+            [\\w$]+
+          )*
+          (?:
+            \\s*
+            (=)                                                # [foo=bar] Default parameter value
+            \\s*
+            (
+              # The inner regexes are to stop the match early at */ and to not stop at escaped quotes
+              (?>
+                "(?:(?:\\*(?!/))|(?:\\\\(?!"))|[^*\\\\])*?" |  # [foo="bar"] Double-quoted
+                '(?:(?:\\*(?!/))|(?:\\\\(?!'))|[^*\\\\])*?' |  # [foo='bar'] Single-quoted
+                \\[ (?:(?:\\*(?!/))|[^*])*? \\] |              # [foo=[1,2]] Array literal
+                (?:(?:\\*(?!/))|\\s(?!\\s*\\])|\\[.*?(?:\\]|(?=\\*/))|[^*\\s\\[\\]])* # Everything else (sorry)
+              )*
+            )
+          )?
+          \\s*(?:(\\])((?:[^*\\s]|\\*[^\\s/])+)?|(?=\\*/))
+        '''
+        'captures':
+          '1':
+            'name': 'punctuation.definition.optional-value.begin.bracket.square.sassdoc'
+          '2':
+            'name': 'keyword.operator.assignment.sassdoc'
+          '3':
+            'name': 'source.embedded.js'
+            'patterns': [
+              {
+                'include': '#inline-tags'
+              }
+              {
+                'include': 'source.js'
+              }
+            ]
+          '4':
+            'name': 'punctuation.definition.optional-value.end.bracket.square.sassdoc'
+          '5':
+            'name': 'invalid.illegal.syntax.sassdoc'
+      }
+    ]
+  }
+  {
+    # Tags followed by a type expression
+    # -  @<tag> {type}
+    'begin': '''(?x)
+      (
+        (@)
+        (?:returns?|throws?|exception|type|outputs?)
+      )
+      \\s+(?={)
+    '''
+    'beginCaptures':
+      '1':
+        'name': 'storage.type.class.sassdoc'
+      '2':
+        'name': 'punctuation.definition.block.tag.sassdoc'
+    'end': '(?=\\s|[^{}\\[\\]A-Za-z_$])'
+    'patterns': [
+      {
+        'include': '#sassdoctype'
+      }
+    ]
+  }
+  {
+    # Tags followed by a namepath
+    # -  @<tag> namepath
+    'match': '''(?x)
+      (
+        (@)
+        (?:alias|group|name|requires?|see)
+      )
+      \\s+
+      (
+        (?:
+          [^{}@\\s*] | \\*[^/]
+        )+
+      )
+    '''
+    'captures':
+      '1':
+        'name': 'storage.type.class.sassdoc'
+      '2':
+        'name': 'punctuation.definition.block.tag.sassdoc'
+      '3':
+        'name': 'entity.name.type.instance.sassdoc'
+  }
+  {
+    'name': 'storage.type.class.sassdoc',
+    'match': '''(?x)
+      (@)
+      (?:access|alias|author|content|deprecated|example|exception|group
+      |ignore|name|prop|property|requires?|returns?|see|since|throws?|todo
+      |type|outputs?)
+      \\b
+    '''
+    'captures':
+      '1':
+        'name': 'punctuation.definition.block.tag.sassdoc'
+  }
+  {
+    'include': '#inline-tags'
+  }
+]
+
+'repository':
+  # Balanced brackets (square or curly)
+  'brackets':
+    'patterns': [
+      {
+        'begin': '{'
+        'end': '}|(?=$)'
+        'patterns': [
+          {
+            'include': '#brackets'
+          }
+        ]
+      }
+      {
+        'begin': '\\['
+        'end': '\\]|(?=$)'
+        'patterns': [
+          {
+            'include': '#brackets'
+          }
+        ]
+      }
+    ]
+
+  'inline-tags':
+    'patterns': [
+      {
+        # Description preceding {@inline tag}
+        'captures':
+          '1':
+            'name': 'punctuation.definition.bracket.square.begin.sassdoc'
+          '2':
+            'name': 'punctuation.definition.bracket.square.end.sassdoc'
+        'match': '(\\[)[^\\]]+(\\])(?={@(?:link))'
+        'name': 'constant.other.description.sassdoc'
+      }
+      {
+        # {@link …}
+        'begin': '({)((@)(?:link))\\s*'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.bracket.curly.begin.sassdoc'
+          '2':
+            'name': 'storage.type.class.sassdoc'
+          '3':
+            'name': 'punctuation.definition.inline.tag.sassdoc'
+        'end': '}|(?=$)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.bracket.curly.end.sassdoc'
+        'name': 'entity.name.type.instance.sassdoc'
+        'patterns': [
+          {
+            'captures':
+              '1':
+                'name': 'variable.other.link.underline.sassdoc'
+              '2':
+                'name': 'punctuation.separator.pipe.sassdoc'
+            'match': '\\G((?=https?://)(?:[^|}\\s*]|\\*[/])+)(\\|)?'
+          }
+          {
+            'captures':
+              '1':
+                'name': 'variable.other.description.sassdoc'
+              '2':
+                'name': 'punctuation.separator.pipe.sassdoc'
+            'match': '\\G((?:[^{}@\\s|*]|\\*[^/])+)(\\|)?'
+          }
+        ]
+      }
+    ]
+
+  # {type}
+  'sassdoctype':
+    'patterns': [
+      {
+        # {unclosed
+        'name': 'invalid.illegal.type.sassdoc'
+        'match': '\\G{(?:[^}*]|\\*[^/}])+$'
+      }
+      {
+        'begin': '\\G({)'
+        'beginCaptures':
+          '0':
+            'name': 'entity.name.type.instance.sassdoc'
+          '1':
+            'name': 'punctuation.definition.bracket.curly.begin.sassdoc'
+        'contentName': 'entity.name.type.instance.sassdoc'
+        'end': '((}))\\s*|(?=$)'
+        'endCaptures':
+          '1':
+            'name': 'entity.name.type.instance.sassdoc'
+          '2':
+            'name': 'punctuation.definition.bracket.curly.end.sassdoc'
+        'patterns': [
+          {
+            'include': '#brackets'
+          }
+        ]
+      }
+    ]

--- a/grammars/sassdoc.cson
+++ b/grammars/sassdoc.cson
@@ -175,53 +175,16 @@
         'name': 'entity.name.type.instance.sassdoc'
   }
   {
-    # @see namepathOrURL
-    'match': '''(?x)
-      ((@)see)
-      \\s+
-      (?:
-        # URL
-        (
-          (?=https?://)
-          (?:[^\\s*]|\\*[^/])+
-        )
-        |
-        # JSDoc namepath
-        (
-          (?!
-            # Avoid matching bare URIs (also acceptable as links)
-            https?://
-            |
-            # Avoid matching {@inline tags}; we match those below
-            (?:\\[[^\\[\\]]*\\])? # Possible description [preceding]{@tag}
-            {@(?:link|linkcode|linkplain|tutorial)\\b
-          )
-          # Matched namepath
-          (?:[^@\\s*/]|\\*[^/])+
-        )
-      )
-    '''
-    'captures':
-      '1':
-        'name': 'storage.type.class.sassdoc'
-      '2':
-        'name': 'punctuation.definition.block.tag.sassdoc'
-      '3':
-        'name': 'variable.other.link.underline.sassdoc'
-      '4':
-        'name': 'entity.name.type.instance.sassdoc'
-  }
-  {
     # Tags followed by an identifier token
     # - @<tag> identifier
     'match': '''(?x)
       (
         (@)
-        (?:arg|argument|param|parameter)
+        (?:arg|argument|param|parameter|requires?|see)
       )
       \\s+
       (
-        [A-Za-z_$]
+        [A-Za-z_$%]
         [\\w$.\\[\\]]*
       )
     '''
@@ -236,7 +199,7 @@
   {
     # Tags followed by a type expression, then an identifier
     # -  @<tag> {type} identifier
-    'begin': '((@)(?:arg|argument|param|parameter|prop|property))\\s+(?={)'
+    'begin': '((@)(?:arg|argument|param|parameter|prop|property|requires?|see))\\s+(?={)'
     'beginCaptures':
       '1':
         'name': 'storage.type.class.sassdoc'
@@ -248,7 +211,7 @@
         'include': '#sassdoctype'
       }
       {
-        'match': '([A-Za-z_$][\\w$.\\[\\]]*)'
+        'match': '([A-Za-z_$%][\\-\\w$.\\[\\]]*)'
         'name': 'variable.other.sassdoc'
       }
       {

--- a/grammars/sassdoc.cson
+++ b/grammars/sassdoc.cson
@@ -180,12 +180,12 @@
     'match': '''(?x)
       (
         (@)
-        (?:arg|argument|param|parameter|requires?|see)
+        (?:arg|argument|param|parameter|requires?|see|colors?|fonts?|ratios?|sizes?)
       )
       \\s+
       (
         [A-Za-z_$%]
-        [\\w$.\\[\\]]*
+        [\\-\\w$.\\[\\]]*
       )
     '''
     'captures':
@@ -199,7 +199,7 @@
   {
     # Tags followed by a type expression, then an identifier
     # -  @<tag> {type} identifier
-    'begin': '((@)(?:arg|argument|param|parameter|prop|property|requires?|see))\\s+(?={)'
+    'begin': '((@)(?:arg|argument|param|parameter|prop|property|requires?|see|sizes?))\\s+(?={)'
     'beginCaptures':
       '1':
         'name': 'storage.type.class.sassdoc'
@@ -288,7 +288,7 @@
     'match': '''(?x)
       (
         (@)
-        (?:alias|group|name|requires?|see)
+        (?:alias|group|name|requires?|see|icons?)
       )
       \\s+
       (

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -721,6 +721,18 @@
         'include': '$self'
       }
     ]
+  'comment_docblock':
+    'name': 'comment.block.documentation.scss'
+    'begin': '///'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.comment.scss'
+    'end': '(?=$)'
+    'patterns': [
+      {
+        'include': 'source.sassdoc'
+      }
+    ]
   'comment_block':
     'begin': '/\\*'
     'beginCaptures':

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -434,6 +434,9 @@
         'name': 'meta.at-rule.media.scss'
         'patterns': [
           {
+            'include': '#comment_docblock'
+          }
+          {
             'include': '#comment_block'
           }
           {
@@ -866,6 +869,9 @@
         'include': '#variable'
       }
       {
+        'include': '#comment_docblock'
+      }
+      {
         'include': '#comment_block'
       }
       {
@@ -916,6 +922,9 @@
         'name': 'punctuation.definition.map.end.bracket.round.scss'
     'name': 'meta.definition.variable.map.scss'
     'patterns': [
+      {
+        'include': '#comment_docblock'
+      }
       {
         'include': '#comment_block'
       }
@@ -1535,6 +1544,9 @@
             'name': 'punctuation.separator.key-value.scss'
         'end': '(?=;)'
         'patterns': [
+          {
+            'include': '#comment_docblock'
+          }
           {
             'include': '#comment_block'
           }

--- a/spec/sassdoc-spec.coffee
+++ b/spec/sassdoc-spec.coffee
@@ -1,0 +1,62 @@
+describe 'SassDoc grammar', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage('language-sass')
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName('source.css.scss')
+
+  describe 'block tags', ->
+    it 'tokenises simple tags', ->
+      {tokens} = grammar.tokenizeLine('/// @deprecated')
+      expect(tokens[0]).toEqual value: '///', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'punctuation.definition.comment.scss']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.css.scss', 'comment.block.documentation.scss']
+      expect(tokens[2]).toEqual value: '@', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'storage.type.class.sassdoc', 'punctuation.definition.block.tag.sassdoc']
+      expect(tokens[3]).toEqual value: 'deprecated', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'storage.type.class.sassdoc']
+
+    it 'tokenises @param tags with a description', ->
+      {tokens} = grammar.tokenizeLine('/// @param {type} $name - Description')
+      expect(tokens[0]).toEqual value: '///', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'punctuation.definition.comment.scss']
+      expect(tokens[2]).toEqual value: '@', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'storage.type.class.sassdoc', 'punctuation.definition.block.tag.sassdoc']
+      expect(tokens[3]).toEqual value: 'param', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'storage.type.class.sassdoc']
+      expect(tokens[5]).toEqual value: '{', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'entity.name.type.instance.sassdoc', 'punctuation.definition.bracket.curly.begin.sassdoc']
+      expect(tokens[6]).toEqual value: 'type', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'entity.name.type.instance.sassdoc']
+      expect(tokens[7]).toEqual value: '}', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'entity.name.type.instance.sassdoc', 'punctuation.definition.bracket.curly.end.sassdoc']
+      expect(tokens[9]).toEqual value: '$name', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'variable.other.sassdoc']
+      expect(tokens[10]).toEqual value: ' - Description', scopes: ['source.css.scss', 'comment.block.documentation.scss']
+
+  describe 'highlighted examples', ->
+    it 'highlights SCSS after an @example tag', ->
+      lines = grammar.tokenizeLines '''
+        ///
+        /// @example scss - Description
+        ///   .class{top:clamp(42,$min: 13)}
+        ///
+      '''
+      expect(lines[1][0]).toEqual value: '///', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'punctuation.definition.comment.scss']
+      expect(lines[1][1]).toEqual value: ' ', scopes: ['source.css.scss', 'comment.block.documentation.scss']
+      expect(lines[1][2]).toEqual value: '@', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'storage.type.class.sassdoc', 'punctuation.definition.block.tag.sassdoc']
+      expect(lines[1][3]).toEqual value: 'example', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'storage.type.class.sassdoc']
+      expect(lines[1][4]).toEqual value: ' ', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc']
+      expect(lines[1][5]).toEqual value: 'scss', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'variable.other.sassdoc']
+      expect(lines[1][6]).toEqual value: ' ', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc']
+      expect(lines[1][7]).toEqual value: '- Description', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss']
+
+      expect(lines[2][0]).toEqual value: '///   ', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc']
+      expect(lines[2][1]).toEqual value: '.', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'entity.other.attribute-name.class.css', 'punctuation.definition.entity.css']
+      expect(lines[2][2]).toEqual value: 'class', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'entity.other.attribute-name.class.css']
+      expect(lines[2][3]).toEqual value: '{', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
+      expect(lines[2][4]).toEqual value: 'top', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'meta.property-list.scss', 'meta.property-name.scss']
+      expect(lines[2][5]).toEqual value: ':', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'meta.property-list.scss', 'punctuation.separator.key-value.scss']
+      expect(lines[2][6]).toEqual value: 'clamp', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.function.misc.scss']
+      expect(lines[2][7]).toEqual value: '(', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
+      expect(lines[2][8]).toEqual value: '42', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.parameter.url.scss']
+      expect(lines[2][9]).toEqual value: ',', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.separator.delimiter.scss']
+      expect(lines[2][10]).toEqual value: '$min', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
+      expect(lines[2][11]).toEqual value: ':', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.parameter.url.scss']
+      expect(lines[2][12]).toEqual value: ' ', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'meta.property-list.scss', 'meta.property-value.scss']
+      expect(lines[2][13]).toEqual value: '13', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.parameter.url.scss']
+      expect(lines[2][14]).toEqual value: ')', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
+      expect(lines[2][15]).toEqual value: '}', scopes: ['source.css.scss', 'comment.block.documentation.scss', 'meta.example.css.scss.sassdoc', 'source.embedded.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.end.bracket.curly.scss']


### PR DESCRIPTION
<!-- 🚧 Still a bit of a work-in-progress — need to figure out some tests, and check that it works in `.sass` files as well — but wanted to open the PR for comment/feedback. -->

### Description of the Change

Adds grammar patterns for highlighting [SassDoc](http://sassdoc.com) comments, similar to how JSDoc blocks are handled in `language-javascript`.

### Benefits

Having docblocks highlighted makes them easier to read, and can encourage their use.
