### PR TITLE
Import strings can also use single quotation marks

### DIFF
--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -418,6 +418,9 @@
     'name': 'meta.at-rule.import.sass'
     'patterns': [
       {
+        'include': '#string-single'
+      }
+      {
         'include': '#string-double'
       }
       {


### PR DESCRIPTION
This sass grammar allows single quoted strings wherever double quoted ones are also allowed, except for `@import` lines. This fixes that, allowing single quoted strings there also, as sass does.