### PR TITLE
Add null constant and remove .css for booleans/null

### DIFF
--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -654,8 +654,8 @@
         'include': '#variable-usage'
       }
       {
-        'match': '\\b(true|false)\\b'
-        'name': 'support.constant.property-value.css.sass'
+        'match': '\\b(true|false|null)\\b'
+        'name': 'support.constant.property-value.sass'
       }
       {
         'include': 'source.css#property-keywords'


### PR DESCRIPTION
`null` seems to be in the SCSS grammar but not the SASS grammar.

http://sass-lang.com/documentation/file.SASS_REFERENCE.html#data_types

Also, I couldn't find any reference to true/false being valid CSS properties, so I removed the `.css` attribute for them.