### PR TITLE
fix: `@each` block end

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -115,7 +115,7 @@
         'name': 'keyword.control.each.scss'
       '2':
         'name': 'punctuation.definition.keyword.scss'
-    'end': '\\s*((?=}))'
+    'end': '\\s*((?={))'
     'name': 'meta.at-rule.each.scss'
     'patterns': [
       {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Fixes, syntax highlighting for `@each` statements. Updated to match the other control flow/iteration patterns (see `if`, `else`, `for`, etc)

old:
![image](https://user-images.githubusercontent.com/339286/66486143-0a391900-ea78-11e9-8e95-9fa8f882a065.png)

new: 
![image](https://user-images.githubusercontent.com/339286/66486101-fc839380-ea77-11e9-9060-c12b7301f7c9.png)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Code will be highlighted more accurately. Specifically in nested language cases, such as CSS-in-js style colocation of scss styles in js

### Possible Drawbacks

It could be the wrong fix?

### Applicable Issues

Fixes #267 