### PR TITLE
SASS Modules (@use and @forward)

### DIFF
--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -335,6 +335,46 @@
     ]
   }
   {
+    'begin': '\\s*((@)forward\\b)\\s*'
+    'captures':
+      '1':
+        'name': 'keyword.control.at-rule.forward.sass'
+      '2':
+        'name': 'punctuation.definition.keyword.sass'
+    'end': '\\s*(?=;)'
+    'name': 'meta.at-rule.forward.sass'
+    'patterns': [
+      {
+        'match': '\\b(as|hide|show)\\b'
+        'name': 'keyword.control.operator'
+      }
+      {
+        'match': '\\b([\\w-]+)(\\*)'
+        'captures':
+          '1':
+            'name': 'entity.other.attribute-name.module.sass'
+          '2':
+            'name': 'punctuation.definition.wildcard.sass'
+      }
+      {
+        'match': '\\b[\\w-]+(?!\\*)'
+        'name': 'variable.sass'
+      }
+      {
+        'include': '#variable-usage'
+      }
+      {
+        'include': '#string-single'
+      }
+      {
+        'include': '#string-double'
+      }
+      {
+        'include': '#comments'
+      }
+    ]
+  }
+  {
     'begin': '^\\s*(\\+)([a-zA-Z0-9_-]+)'
     'beginCaptures':
       '1':

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -204,13 +204,17 @@
     ]
   }
   {
-    'begin': '^\\s*(\\+(?!\\s+)|(?:(@)include(?=\\s+)))\\s*([a-zA-Z0-9_-]+)'
+    'begin': '^\\s*(\\+(?!\\s+)|(?:(@)include(?=\\s+)))\\s*(?:([\\w-]+)(\\.))?([a-zA-Z0-9_-]+)'
     'beginCaptures':
       '1':
         'name': 'keyword.control.at-rule.include.sass'
       '2':
         'name': 'punctuation.definition.entity.sass'
       '3':
+        'name': 'variable.sass'
+      '4':
+        'name': 'punctuation.acess.module.sass'
+      '5':
         'name': 'variable.other.sass'
     'end': '(;)?$'
     'endCaptures':

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -357,8 +357,8 @@
             'name': 'punctuation.definition.wildcard.sass'
       }
       {
-        'match': '\\b[\\w-]+(?!\\*)'
-        'name': 'variable.sass'
+        'match': '\\b[\\w-]+\\b'
+        'name': 'entity.name.function.scss'
       }
       {
         'include': '#variable-usage'

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -772,6 +772,36 @@
         'include': '#string-single'
       }
       {
+        'begin': '([\\w-]+)(\\.)([\\w-]+)(\\()'
+        'beginCaptures':
+          '1':
+            'name': 'variable.sass'
+          '2':
+            'name': 'punctuation.access.module.sass'
+          '3':
+            'name': 'support.function.misc.sass'
+          '4':
+            'name': 'punctuation.section.function.sass'
+        'end': '(\\))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.section.function.sass'
+        'patterns': [
+          {
+            'include': '#string-double'
+          }
+          {
+            'include': '#string-single'
+          }
+          {
+            'include': '#variable-usage'
+          }
+          {
+            'include': 'source.css#numeric-values'
+          }
+        ]
+      }
+      {
         'begin': '(rgb|url|attr|counter|counters|local|format)\\s*(\\()'
         'beginCaptures':
           '1':

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -808,10 +808,14 @@
       }
     ]
   'variable-usage':
-    'match': '(!|\\$)([a-zA-Z0-9_-]+)'
+    'match': '(?:([\\w-]+)(\\.)(?=\\$))?(!|\\$)([a-zA-Z0-9_-]+)'
     'name': 'meta.variable-usage.sass'
     'captures':
       '1':
-        'name': 'punctuation.definition.entity.css'
+        'name': 'variable.sass'
       '2':
+        'name': 'punctuation.acess.module.sass'
+      '3':
+        'name': 'punctuation.definition.entity.css'
+      '4':
         'name': 'variable.other.sass'

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -358,7 +358,7 @@
       }
       {
         'match': '\\b[\\w-]+\\b'
-        'name': 'entity.name.function.scss'
+        'name': 'entity.name.function.sass'
       }
       {
         'include': '#variable-usage'

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -213,7 +213,7 @@
       '3':
         'name': 'variable.sass'
       '4':
-        'name': 'punctuation.acess.module.sass'
+        'name': 'punctuation.access.module.sass'
       '5':
         'name': 'variable.other.sass'
     'end': '(;)?$'
@@ -854,7 +854,7 @@
       '1':
         'name': 'variable.sass'
       '2':
-        'name': 'punctuation.acess.module.sass'
+        'name': 'punctuation.access.module.sass'
       '3':
         'name': 'punctuation.definition.entity.css'
       '4':

--- a/grammars/sass.cson
+++ b/grammars/sass.cson
@@ -280,6 +280,57 @@
     ]
   }
   {
+    'begin': '^\\s*((@)use\\b)\\s*'
+    'beginCaptures':
+      '1':
+        'name': 'keyword.control.at-rule.use.sass'
+      '2':
+        'name': 'punctuation.definition.keyword.sass'
+    'end': '(;)?$'
+    'endCaptures':
+      '1':
+        'name': 'invalid.illegal.punctuation.sass'
+    'name': 'meta.at-rule.use.sass'
+    'patterns': [
+      {
+        'match': '\\b(as|with)\\b'
+        'name': 'keyword.control.operator'
+      }
+      {
+        'match': '\\b[\\w-]+\\b'
+        'name': 'variable.sass'
+      }
+      {
+        'match': '\\*'
+        'name': 'variable.language.expanded-namespace.sass'
+      }
+      {
+        'include': '#string-single'
+      }
+      {
+        'include': '#string-double'
+      }
+      {
+        'include': '#comments'
+      }
+      {
+        'begin': '\\(',
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.module.begin.bracket.round.sass'
+        'end': '\\)',
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.module.end.bracket.round.sass'
+        'patterns': [
+          {
+            'include': '#property-value'
+          }
+        ]
+      }
+    ]
+  }
+  {
     'begin': '^\\s*(\\+)([a-zA-Z0-9_-]+)'
     'beginCaptures':
       '1':

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -243,8 +243,8 @@
             'name': 'punctuation.definition.wildcard.scss'
       }
       {
-        'match': '\\b[\\w-]+(?!\\*)'
-        'name': 'variable.scss'
+        'match': '\\b[\\w-]+\\b'
+        'name': 'entity.name.function.scss'
       }
       {
         'include': '#variable'

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -12,6 +12,9 @@
     'include': '#variable_setting'
   }
   {
+    'include': '#at_rule_forward'
+  }
+  {
     'include': '#at_rule_use'
   }
   {
@@ -215,6 +218,48 @@
       }
       {
         'include': '$self'
+      }
+    ]
+  'at_rule_forward':
+    'begin': '\\s*((@)forward\\b)\\s*'
+    'captures':
+      '1':
+        'name': 'keyword.control.at-rule.forward.scss'
+      '2':
+        'name': 'punctuation.definition.keyword.scss'
+    'end': '\\s*(?=;)'
+    'name': 'meta.at-rule.forward.scss'
+    'patterns': [
+      {
+        'match': '\\b(as|hide|show)\\b'
+        'name': 'keyword.control.operator'
+      }
+      {
+        'match': '\\b([\\w-]+)(\\*)'
+        'captures':
+          '1':
+            'name': 'entity.other.attribute-name.module.scss'
+          '2':
+            'name': 'punctuation.definition.wildcard.scss'
+      }
+      {
+        'match': '\\b[\\w-]+(?!\\*)'
+        'name': 'variable.scss'
+      }
+      {
+        'include': '#variable'
+      }
+      {
+        'include': '#string_single'
+      }
+      {
+        'include': '#string_double'
+      }
+      {
+        'include': '#comment_line'
+      }
+      {
+        'include': '#comment_block'
       }
     ]
   'at_rule_function':

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -344,7 +344,7 @@
   'at_rule_include':
     'patterns': [
       {
-        'begin': '(?<=@include)\\s+([\\w-]+)\\s*(\\.)\\s*([\\w-]+)\\s*(\\()'
+        'begin': '(?<=@include)\\s+(?:([\\w-]+)\\s*(\\.))?([\\w-]+)\\s*(\\()'
         'beginCaptures':
           '1':
             'name': 'variable.scss'
@@ -366,7 +366,7 @@
         ]
       }
       {
-        'match': '(?<=@include)\\s+([\\w-]+)\\s*(\\.)\\s*([\\w-]+)'
+        'match': '(?<=@include)\\s+(?:([\\w-]+)\\s*(\\.))?([\\w-]+)'
         'captures':
           '0':
             'name': 'meta.at-rule.include.scss'
@@ -375,32 +375,6 @@
           '2':
             'name': 'punctuation.acess.module.scss'
           '3':
-            'name': 'entity.name.function.scss'
-      }
-      {
-        'begin': '(?<=@include)\\s+([\\w-]+)\\s*(\\()'
-        'beginCaptures':
-          '1':
-            'name': 'entity.name.function.scss'
-          '2':
-            'name': 'punctuation.definition.parameters.begin.bracket.round.scss'
-        'end': '\\)'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.parameters.end.bracket.round.scss'
-        'name': 'meta.at-rule.include.scss'
-        'patterns': [
-          {
-            'include': '#function_attributes'
-          }
-        ]
-      }
-      {
-        'match': '(?<=@include)\\s+([\\w-]+)'
-        'captures':
-          '0':
-            'name': 'meta.at-rule.include.scss'
-          '1':
             'name': 'entity.name.function.scss'
       }
       {
@@ -888,47 +862,27 @@
   'constant_default':
     'match': '!default'
     'name': 'keyword.other.default.scss'
-  'constant_functions':
+  'constant_functions': {
+    'begin': '(?:([\\w-]+)(\\.))?([\\w-]+)(\\()'
+    'beginCaptures':
+      '1':
+        'name': 'variable.scss'
+      '2':
+        'name': 'punctuation.acess.module.scss'
+      '3':
+        'name': 'support.function.misc.scss'
+      '4':
+        'name': 'punctuation.section.function.scss'
+    'end': '(\\))'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.section.function.scss'
     'patterns': [
       {
-        'begin': '([\\w-]+)(\\()'
-        'beginCaptures':
-          '1':
-            'name': 'support.function.misc.scss'
-          '2':
-            'name': 'punctuation.section.function.scss'
-        'end': '(\\))'
-        'endCaptures':
-          '1':
-            'name': 'punctuation.section.function.scss'
-        'patterns': [
-          {
-            'include': '#parameters'
-          }
-        ]
-      }
-      {
-        'begin': '([\\w-]+)\\s*(\\.)\\s*([\\w-]+)(\\()'
-        'beginCaptures':
-          '1':
-            'name': 'variable.scss'
-          '2':
-            'name': 'punctuation.acess.module.scss'
-          '3':
-            'name': 'support.function.misc.scss'
-          '4':
-            'name': 'punctuation.section.function.scss'
-        'end': '(\\))'
-        'endCaptures':
-          '1':
-            'name': 'punctuation.section.function.scss'
-        'patterns': [
-          {
-            'include': '#parameters'
-          }
-        ]
+        'include': '#parameters'
       }
     ]
+  }
   'constant_important':
     'match': '!important'
     'name': 'keyword.other.important.scss'

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1005,10 +1005,10 @@
     'name': 'variable.interpolation.scss'
     'patterns': [
       {
-        'include': '#property_values'
+        'include': '#variable'
       }
       {
-        'include': '#variable'
+        'include': '#property_values'
       }
     ]
   'conditional_operators':
@@ -1062,10 +1062,10 @@
         'include': '#map'
       }
       {
-        'include': '#property_values'
+        'include': '#variable'
       }
       {
-        'include': '#variable'
+        'include': '#property_values'
       }
     ]
   'operators':
@@ -1256,7 +1256,7 @@
           [-a-zA-Z_0-9]|[^\\x00-\\x7F]       # Valid identifier characters
           | \\\\(?:[0-9a-fA-F]{1,6}|.)       # Escape sequence
           | \\#\\{                           # Interpolation (escaped to avoid Coffeelint errors)
-          | \\$                              # Possible start of interpolation variable
+          | \\.?\\$                          # Possible start of interpolation variable
           | }                                # Possible end of interpolation
         )+?
       )
@@ -1268,7 +1268,7 @@
               [-a-zA-Z_0-9]|[^\\x00-\\x7F]       # Valid identifier characters
               | \\\\(?:[0-9a-fA-F]{1,6}|.)       # Escape sequence
               | \\#\\{                           # Interpolation (escaped to avoid Coffeelint errors)
-              | \\$                              # Possible start of interpolation variable
+              | \\.?\\$                          # Possible start of interpolation variable
               | }                                # Possible end of interpolation
             )+
           )
@@ -1370,12 +1370,13 @@
         (?: [-a-zA-Z_0-9]|[^\\x00-\\x7F]     # Valid identifier characters
           | \\\\(?:[0-9a-fA-F]{1,6}|.)       # Escape sequence
           | \\#\\{                           # Interpolation (escaped to avoid Coffeelint errors)
-          | \\$                              # Possible start of interpolation variable
+          | \\.?\\$                          # Possible start of interpolation variable
           | }                                # Possible end of interpolation
         )+
       )                                      # Followed by either:
       (?= $                                  # - End of the line
-        | [\\s,.\\#)\\[:{>+~|]               # - Another selector
+        | [\\s,\\#)\\[:{>+~|]                # - Another selector
+        | \\.[^$]                            # - Class selector, negating module variable
         | /\\*                               # - A block comment
       )
     '''
@@ -1408,12 +1409,13 @@
         (?: [-a-zA-Z_0-9]|[^\\x00-\\x7F]     # Valid identifier characters
           | \\\\(?:[0-9a-fA-F]{1,6}|.)       # Escape sequence
           | \\#\\{                           # Interpolation (escaped to avoid Coffeelint errors)
-          | \\$                              # Possible start of interpolation variable
+          | \\.?\\$                          # Possible start of interpolation variable
           | }                                # Possible end of interpolation
         )+
       )                                      # Followed by either:
       (?= $                                  # - End of the line
-        | [\\s,.\\#)\\[:{>+~|]               # - Another selector
+        | [\\s,\\#)\\[:{>+~|]                # - Another selector
+        | \\.[^$]                            # - Class selector, negating module variable
         | /\\*                               # - A block comment
       )
     '''
@@ -1443,13 +1445,15 @@
         (?: [-a-zA-Z_0-9]|[^\\x00-\\x7F]     # Valid identifier characters
           | \\\\(?:[0-9a-fA-F]{1,6}|.)       # Escape sequence
           | \\#\\{                           # Interpolation (escaped to avoid Coffeelint errors)
+          | \\.\\$                           # Possible start of interpolation module scope variable
           | \\$                              # Possible start of interpolation variable
           | }                                # Possible end of interpolation
         )+
       )                                      # Followed by either:
       (?= ;                                  # - End of statement
         | $                                  # - End of the line
-        | [\\s,.\\#)\\[:{>+~|]               # - Another selector
+        | [\\s,\\#)\\[:{>+~|]                # - Another selector
+        | \\.[^$]                            # - Class selector, negating module variable
         | /\\*                               # - A block comment
       )
     '''
@@ -1685,5 +1689,19 @@
       }
     ]
   'variables':
-    'match': '(\\$|\\-\\-)[A-Za-z0-9_-]+\\b'
-    'name': 'variable.scss'
+    'patterns': [
+      {
+        'match': '\\b([\\w-]+)(\\.)(\\$[\\w-]+)\\b'
+        'captures':
+          '1':
+            'name': 'variable.scss'
+          '2':
+            'name': 'punctuation.acess.module.scss'
+          '3':
+            'name': 'variable.scss'
+      }
+      {
+        'match': '(\\$|\\-\\-)[A-Za-z0-9_-]+\\b'
+        'name': 'variable.scss'
+      }
+    ]

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -299,6 +299,40 @@
   'at_rule_include':
     'patterns': [
       {
+        'begin': '(?<=@include)\\s+([\\w-]+)\\s*(\\.)\\s*([\\w-]+)\\s*(\\()'
+        'beginCaptures':
+          '1':
+            'name': 'variable.scss'
+          '2':
+            'name': 'punctuation.acess.module.scss'
+          '3':
+            'name': 'entity.name.function.scss'
+          '4':
+            'name': 'punctuation.definition.parameters.begin.bracket.round.scss'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.parameters.end.bracket.round.scss'
+        'name': 'meta.at-rule.include.scss'
+        'patterns': [
+          {
+            'include': '#function_attributes'
+          }
+        ]
+      }
+      {
+        'match': '(?<=@include)\\s+([\\w-]+)\\s*(\\.)\\s*([\\w-]+)'
+        'captures':
+          '0':
+            'name': 'meta.at-rule.include.scss'
+          '1':
+            'name': 'variable.scss'
+          '2':
+            'name': 'punctuation.acess.module.scss'
+          '3':
+            'name': 'entity.name.function.scss'
+      }
+      {
         'begin': '(?<=@include)\\s+([\\w-]+)\\s*(\\()'
         'beginCaptures':
           '1':

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -813,19 +813,44 @@
     'match': '!default'
     'name': 'keyword.other.default.scss'
   'constant_functions':
-    'begin': '([\\w-]+)(\\()'
-    'beginCaptures':
-      '1':
-        'name': 'support.function.misc.scss'
-      '2':
-        'name': 'punctuation.section.function.scss'
-    'end': '(\\))'
-    'endCaptures':
-      '1':
-        'name': 'punctuation.section.function.scss'
     'patterns': [
       {
-        'include': '#parameters'
+        'begin': '([\\w-]+)(\\()'
+        'beginCaptures':
+          '1':
+            'name': 'support.function.misc.scss'
+          '2':
+            'name': 'punctuation.section.function.scss'
+        'end': '(\\))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.section.function.scss'
+        'patterns': [
+          {
+            'include': '#parameters'
+          }
+        ]
+      }
+      {
+        'begin': '([\\w-]+)\\s*(\\.)\\s*([\\w-]+)(\\()'
+        'beginCaptures':
+          '1':
+            'name': 'variable.scss'
+          '2':
+            'name': 'punctuation.acess.module.scss'
+          '3':
+            'name': 'support.function.misc.scss'
+          '4':
+            'name': 'punctuation.section.function.scss'
+        'end': '(\\))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.section.function.scss'
+        'patterns': [
+          {
+            'include': '#parameters'
+          }
+        ]
       }
     ]
   'constant_important':

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -12,6 +12,9 @@
     'include': '#variable_setting'
   }
   {
+    'include': '#at_rule_use'
+  }
+  {
     'include': '#at_rule_include'
   }
   {
@@ -679,6 +682,59 @@
       {
         'match': '\\)'
         'name': 'punctuation.definition.condition.end.bracket.round.scss'
+      }
+    ]
+  'at_rule_use':
+    'begin': '\\s*((@)use\\b)\\s*'
+    'captures':
+      '1':
+        'name': 'keyword.control.at-rule.use.scss'
+      '2':
+        'name': 'punctuation.definition.keyword.scss'
+    'end': '\\s*(?=;)'
+    'name': 'meta.at-rule.use.scss'
+    'patterns': [
+      {
+        'match': '\\b(as|with)\\b'
+        'name': 'keyword.control.operator'
+      }
+      {
+        'match': '\\b[\\w-]+\\b'
+        'name': 'variable.scss'
+      }
+      {
+        'match': '\\*'
+        'name': 'variable.language.expanded-namespace.scss'
+      }
+      {
+        'include': '#string_single'
+      }
+      {
+        'include': '#string_double'
+      }
+      {
+        'include': '#comment_line'
+      }
+      {
+        'include': '#comment_block'
+      }
+      {
+        'include': '#comment_block'
+      }
+      {
+        'begin': '\\(',
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.parameters.begin.bracket.round.scss'
+        'end': '\\)',
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.parameters.end.bracket.round.scss'
+        'patterns': [
+          {
+            'include': '#function_attributes'
+          }
+        ]
       }
     ]
   'at_rule_warn':

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -349,7 +349,7 @@
           '1':
             'name': 'variable.scss'
           '2':
-            'name': 'punctuation.acess.module.scss'
+            'name': 'punctuation.access.module.scss'
           '3':
             'name': 'entity.name.function.scss'
           '4':
@@ -373,7 +373,7 @@
           '1':
             'name': 'variable.scss'
           '2':
-            'name': 'punctuation.acess.module.scss'
+            'name': 'punctuation.access.module.scss'
           '3':
             'name': 'entity.name.function.scss'
       }
@@ -868,7 +868,7 @@
       '1':
         'name': 'variable.scss'
       '2':
-        'name': 'punctuation.acess.module.scss'
+        'name': 'punctuation.access.module.scss'
       '3':
         'name': 'support.function.misc.scss'
       '4':
@@ -1692,7 +1692,7 @@
           '1':
             'name': 'variable.scss'
           '2':
-            'name': 'punctuation.acess.module.scss'
+            'name': 'punctuation.access.module.scss'
           '3':
             'name': 'variable.scss'
       }

--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -753,9 +753,6 @@
         'include': '#comment_block'
       }
       {
-        'include': '#comment_block'
-      }
-      {
         'begin': '\\(',
         'beginCaptures':
           '0':

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -376,14 +376,29 @@ describe 'Sass grammar', ->
       expect(tokens[9]).toEqual value: 'list', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'variable.other.sass']
       # 'in' tested in operators
 
-    it 'tokenizes @include or \'+\'', ->
+    it 'tokenizes @include', ->
       {tokens} = grammar.tokenizeLine '@include mixin-name'
       expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.function.include.sass', 'keyword.control.at-rule.include.sass', 'punctuation.definition.entity.sass']
       expect(tokens[1]).toEqual value: 'include', scopes: ['source.sass', 'meta.function.include.sass', 'keyword.control.at-rule.include.sass']
+      expect(tokens[3]).toEqual value: 'mixin-name', scopes: ['source.sass', 'meta.function.include.sass', 'variable.other.sass']
 
+      {tokens} = grammar.tokenizeLine '@include mixin.name'
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.function.include.sass', 'keyword.control.at-rule.include.sass', 'punctuation.definition.entity.sass']
+      expect(tokens[1]).toEqual value: 'include', scopes: ['source.sass', 'meta.function.include.sass', 'keyword.control.at-rule.include.sass']
+      expect(tokens[3]).toEqual value: 'mixin', scopes: ['source.sass', 'meta.function.include.sass', 'variable.sass']
+      expect(tokens[4]).toEqual value: '.', scopes: ['source.sass', 'meta.function.include.sass', 'punctuation.acess.module.sass']
+      expect(tokens[5]).toEqual value: 'name', scopes: ['source.sass', 'meta.function.include.sass', 'variable.other.sass']
+
+    it 'tokenizes \'+\'', ->
       {tokens} = grammar.tokenizeLine '+mixin-name'
       expect(tokens[0]).toEqual value: '+', scopes: ['source.sass', 'meta.function.include.sass', 'keyword.control.at-rule.include.sass']
       expect(tokens[1]).toEqual value: 'mixin-name', scopes: ['source.sass', 'meta.function.include.sass', 'variable.other.sass']
+
+      {tokens} = grammar.tokenizeLine '+mixin.name'
+      expect(tokens[0]).toEqual value: '+', scopes: ['source.sass', 'meta.function.include.sass', 'keyword.control.at-rule.include.sass']
+      expect(tokens[1]).toEqual value: 'mixin', scopes: ['source.sass', 'meta.function.include.sass', 'variable.sass']
+      expect(tokens[2]).toEqual value: '.', scopes: ['source.sass', 'meta.function.include.sass', 'punctuation.acess.module.sass']
+      expect(tokens[3]).toEqual value: 'name', scopes: ['source.sass', 'meta.function.include.sass', 'variable.other.sass']
 
     it 'tokenizes @mixin or \'=\'', ->
       {tokens} = grammar.tokenizeLine '@mixin mixin-name($p)'

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -434,6 +434,39 @@ describe 'Sass grammar', ->
       expect(tokens[2][1]).toEqual value: '#', scopes: [ 'source.sass', 'meta.selector.css', 'entity.other.attribute-name.id.css.sass', 'punctuation.definition.entity.sass']
       expect(tokens[2][2]).toEqual value: 'id', scopes: ['source.sass', 'meta.selector.css', 'entity.other.attribute-name.id.css.sass']
 
+    describe '@use', ->
+      it 'tokenizes @use with explicit namespace correctly', ->
+        {tokens} = grammar.tokenizeLine "@use 'module' as _mod-ule"
+
+        expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.use.sass', 'keyword.control.at-rule.use.sass', 'punctuation.definition.keyword.sass']
+        expect(tokens[1]).toEqual value: 'use', scopes: ['source.sass', 'meta.at-rule.use.sass', 'keyword.control.at-rule.use.sass']
+        expect(tokens[3]).toEqual value: "'", scopes: ['source.sass', 'meta.at-rule.use.sass', 'string.quoted.single.sass', 'punctuation.definition.string.begin.sass']
+        expect(tokens[4]).toEqual value: 'module', scopes: ['source.sass', 'meta.at-rule.use.sass', 'string.quoted.single.sass']
+        expect(tokens[7]).toEqual value: 'as', scopes: ['source.sass', 'meta.at-rule.use.sass', 'keyword.control.operator']
+        expect(tokens[9]).toEqual value: '_mod-ule', scopes: ['source.sass', 'meta.at-rule.use.sass', 'variable.sass']
+
+      it 'tokenizes @use with wildcard correctly', ->
+        {tokens} = grammar.tokenizeLine "@use 'module' as *;"
+
+        expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.use.sass', 'keyword.control.at-rule.use.sass', 'punctuation.definition.keyword.sass']
+        expect(tokens[1]).toEqual value: 'use', scopes: ['source.sass', 'meta.at-rule.use.sass', 'keyword.control.at-rule.use.sass']
+        expect(tokens[3]).toEqual value: "'", scopes: ['source.sass', 'meta.at-rule.use.sass', 'string.quoted.single.sass', 'punctuation.definition.string.begin.sass']
+        expect(tokens[4]).toEqual value: 'module', scopes: ['source.sass', 'meta.at-rule.use.sass', 'string.quoted.single.sass']
+        expect(tokens[7]).toEqual value: 'as', scopes: ['source.sass', 'meta.at-rule.use.sass', 'keyword.control.operator']
+        expect(tokens[9]).toEqual value: '*', scopes: ['source.sass', 'meta.at-rule.use.sass', 'variable.language.expanded-namespace.sass']
+
+      it 'tokenizes @use with configuration correctly', ->
+        {tokens} = grammar.tokenizeLine "@use 'module' with ($black: #222, $border-radius: 0.1rem)"
+
+        expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.use.sass', 'keyword.control.at-rule.use.sass', 'punctuation.definition.keyword.sass']
+        expect(tokens[1]).toEqual value: 'use', scopes: ['source.sass', 'meta.at-rule.use.sass', 'keyword.control.at-rule.use.sass']
+        expect(tokens[3]).toEqual value: "'", scopes: ['source.sass', 'meta.at-rule.use.sass', 'string.quoted.single.sass', 'punctuation.definition.string.begin.sass']
+        expect(tokens[4]).toEqual value: 'module', scopes: ['source.sass', 'meta.at-rule.use.sass', 'string.quoted.single.sass']
+        expect(tokens[7]).toEqual value: 'with', scopes: ['source.sass', 'meta.at-rule.use.sass', 'keyword.control.operator']
+        expect(tokens[9]).toEqual value: '(', scopes: ['source.sass', 'meta.at-rule.use.sass', 'punctuation.definition.module.begin.bracket.round.sass']
+        expect(tokens[10]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.use.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+        expect(tokens[11]).toEqual value: 'black', scopes: ['source.sass', 'meta.at-rule.use.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+
   describe 'operators', ->
     it 'correctly tokenizes comparison and logical operators', ->
       {tokens} = grammar.tokenizeLine '@if 1 == 1'

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -548,7 +548,7 @@ describe 'Sass grammar', ->
         expect(tokens[3]).toEqual value: "'", scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass', 'punctuation.definition.string.begin.sass']
         expect(tokens[4]).toEqual value: 'module', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass']
         expect(tokens[7]).toEqual value: 'hide', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.operator']
-        expect(tokens[9]).toEqual value: 'a-mixin', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'variable.sass']
+        expect(tokens[9]).toEqual value: 'a-mixin', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'entity.name.function.scss']
         expect(tokens[11]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
         expect(tokens[12]).toEqual value: 'private-variable', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'meta.variable-usage.sass', 'variable.other.sass']
 
@@ -560,7 +560,7 @@ describe 'Sass grammar', ->
         expect(tokens[3]).toEqual value: "'", scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass', 'punctuation.definition.string.begin.sass']
         expect(tokens[4]).toEqual value: 'module', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass']
         expect(tokens[7]).toEqual value: 'show', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.operator']
-        expect(tokens[9]).toEqual value: 'public-mixin', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'variable.sass']
+        expect(tokens[9]).toEqual value: 'public-mixin', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'entity.name.function.scss']
         expect(tokens[11]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
         expect(tokens[12]).toEqual value: 'public-variable', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'meta.variable-usage.sass', 'variable.other.sass']
 

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -345,7 +345,7 @@ describe 'Sass grammar', ->
       expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.control.if.sass', 'punctuation.definition.entity.sass']
       expect(tokens[1]).toEqual value: 'if', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.control.if.sass']
       expect(tokens[3]).toEqual value: 'config', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.variable-usage.sass', 'variable.sass']
-      expect(tokens[4]).toEqual value: '.', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.variable-usage.sass', 'punctuation.acess.module.sass']
+      expect(tokens[4]).toEqual value: '.', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.variable-usage.sass', 'punctuation.access.module.sass']
       expect(tokens[5]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
       expect(tokens[6]).toEqual value: 'setting', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.variable-usage.sass', 'variable.other.sass']
       expect(tokens[8]).toEqual value: '==', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.operator.comparison.sass']
@@ -364,7 +364,7 @@ describe 'Sass grammar', ->
       expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.else.sass', 'keyword.control.else.sass', 'punctuation.definition.entity.sass']
       expect(tokens[1]).toEqual value: 'else if ', scopes: ['source.sass', 'meta.at-rule.else.sass', 'keyword.control.else.sass']
       expect(tokens[2]).toEqual value: 'config', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.variable-usage.sass', 'variable.sass']
-      expect(tokens[3]).toEqual value: '.', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.variable-usage.sass', 'punctuation.acess.module.sass']
+      expect(tokens[3]).toEqual value: '.', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.variable-usage.sass', 'punctuation.access.module.sass']
       expect(tokens[4]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
       expect(tokens[5]).toEqual value: 'setting', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.variable-usage.sass', 'variable.other.sass']
       expect(tokens[7]).toEqual value: '==', scopes: ['source.sass', 'meta.at-rule.else.sass', 'keyword.operator.comparison.sass']
@@ -403,7 +403,7 @@ describe 'Sass grammar', ->
       expect(tokens[3]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
       expect(tokens[4]).toEqual value: 'item', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'variable.other.sass']
       expect(tokens[8]).toEqual value: 'module', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'variable.sass']
-      expect(tokens[9]).toEqual value: '.', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'punctuation.acess.module.sass']
+      expect(tokens[9]).toEqual value: '.', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'punctuation.access.module.sass']
       expect(tokens[10]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
       expect(tokens[11]).toEqual value: 'list', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'variable.other.sass']
       # 'in' tested in operators
@@ -418,7 +418,7 @@ describe 'Sass grammar', ->
       expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.function.include.sass', 'keyword.control.at-rule.include.sass', 'punctuation.definition.entity.sass']
       expect(tokens[1]).toEqual value: 'include', scopes: ['source.sass', 'meta.function.include.sass', 'keyword.control.at-rule.include.sass']
       expect(tokens[3]).toEqual value: 'mixin', scopes: ['source.sass', 'meta.function.include.sass', 'variable.sass']
-      expect(tokens[4]).toEqual value: '.', scopes: ['source.sass', 'meta.function.include.sass', 'punctuation.acess.module.sass']
+      expect(tokens[4]).toEqual value: '.', scopes: ['source.sass', 'meta.function.include.sass', 'punctuation.access.module.sass']
       expect(tokens[5]).toEqual value: 'name', scopes: ['source.sass', 'meta.function.include.sass', 'variable.other.sass']
 
     it 'tokenizes \'+\'', ->
@@ -429,7 +429,7 @@ describe 'Sass grammar', ->
       {tokens} = grammar.tokenizeLine '+mixin.name'
       expect(tokens[0]).toEqual value: '+', scopes: ['source.sass', 'meta.function.include.sass', 'keyword.control.at-rule.include.sass']
       expect(tokens[1]).toEqual value: 'mixin', scopes: ['source.sass', 'meta.function.include.sass', 'variable.sass']
-      expect(tokens[2]).toEqual value: '.', scopes: ['source.sass', 'meta.function.include.sass', 'punctuation.acess.module.sass']
+      expect(tokens[2]).toEqual value: '.', scopes: ['source.sass', 'meta.function.include.sass', 'punctuation.access.module.sass']
       expect(tokens[3]).toEqual value: 'name', scopes: ['source.sass', 'meta.function.include.sass', 'variable.other.sass']
 
     it 'tokenizes @mixin or \'=\'', ->

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -616,3 +616,12 @@ describe 'Sass grammar', ->
         expect(tokens[1][7]).toEqual value: '(', scopes: ['source.sass', 'meta.property-value.sass', 'punctuation.section.function.sass']
         expect(tokens[1][9]).toEqual value: ')', scopes: ['source.sass', 'meta.property-value.sass', 'punctuation.section.function.sass']
 
+      it 'correctly tokenizes module variables', ->
+        tokens = grammar.tokenizeLines '''
+          body
+            font-size: fonts.$size
+        '''
+        expect(tokens[1][4]).toEqual value: 'fonts', scopes: ['source.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'variable.sass']
+        expect(tokens[1][5]).toEqual value: '.', scopes: ['source.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'punctuation.access.module.sass']
+        expect(tokens[1][6]).toEqual value: '$', scopes: ['source.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+        expect(tokens[1][7]).toEqual value: 'size', scopes: ['source.sass', 'meta.property-value.sass', 'meta.variable-usage.sass', 'variable.other.sass']

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -341,6 +341,16 @@ describe 'Sass grammar', ->
       expect(tokens[6]).toEqual value: '==', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.operator.comparison.sass']
       expect(tokens[8]).toEqual value: 'true', scopes: ['source.sass', 'meta.at-rule.if.sass', 'support.constant.property-value.css.sass']
 
+      {tokens} = grammar.tokenizeLine '@if config.$setting == true'
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.control.if.sass', 'punctuation.definition.entity.sass']
+      expect(tokens[1]).toEqual value: 'if', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.control.if.sass']
+      expect(tokens[3]).toEqual value: 'config', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.variable-usage.sass', 'variable.sass']
+      expect(tokens[4]).toEqual value: '.', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.variable-usage.sass', 'punctuation.acess.module.sass']
+      expect(tokens[5]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+      expect(tokens[6]).toEqual value: 'setting', scopes: ['source.sass', 'meta.at-rule.if.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+      expect(tokens[8]).toEqual value: '==', scopes: ['source.sass', 'meta.at-rule.if.sass', 'keyword.operator.comparison.sass']
+      expect(tokens[10]).toEqual value: 'true', scopes: ['source.sass', 'meta.at-rule.if.sass', 'support.constant.property-value.css.sass']
+
     it 'tokenizes @else if', ->
       {tokens} = grammar.tokenizeLine '@else if $var == false'
       expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.else.sass', 'keyword.control.else.sass', 'punctuation.definition.entity.sass']
@@ -349,6 +359,17 @@ describe 'Sass grammar', ->
       expect(tokens[3]).toEqual value: 'var', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.variable-usage.sass', 'variable.other.sass']
       expect(tokens[5]).toEqual value: '==', scopes: ['source.sass', 'meta.at-rule.else.sass', 'keyword.operator.comparison.sass']
       expect(tokens[7]).toEqual value: 'false', scopes: ['source.sass', 'meta.at-rule.else.sass', 'support.constant.property-value.css.sass']
+
+      {tokens} = grammar.tokenizeLine '@else if config.$setting == false'
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.else.sass', 'keyword.control.else.sass', 'punctuation.definition.entity.sass']
+      expect(tokens[1]).toEqual value: 'else if ', scopes: ['source.sass', 'meta.at-rule.else.sass', 'keyword.control.else.sass']
+      expect(tokens[2]).toEqual value: 'config', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.variable-usage.sass', 'variable.sass']
+      expect(tokens[3]).toEqual value: '.', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.variable-usage.sass', 'punctuation.acess.module.sass']
+      expect(tokens[4]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+      expect(tokens[5]).toEqual value: 'setting', scopes: ['source.sass', 'meta.at-rule.else.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+      expect(tokens[7]).toEqual value: '==', scopes: ['source.sass', 'meta.at-rule.else.sass', 'keyword.operator.comparison.sass']
+      expect(tokens[9]).toEqual value: 'false', scopes: ['source.sass', 'meta.at-rule.else.sass', 'support.constant.property-value.css.sass']
+
 
     it 'tokenizes @while', ->
       {tokens} = grammar.tokenizeLine '@while 1'
@@ -364,6 +385,7 @@ describe 'Sass grammar', ->
       expect(tokens[4]).toEqual value: 'i', scopes: ['source.sass', 'meta.at-rule.for.sass', 'meta.variable-usage.sass', 'variable.other.sass']
       expect(tokens[8]).toEqual value: '1', scopes: ['source.sass', 'meta.at-rule.for.sass', 'constant.numeric.css']
       expect(tokens[12]).toEqual value: '100', scopes: ['source.sass', 'meta.at-rule.for.sass', 'constant.numeric.css']
+
       # 'from' and 'thorugh' tested in operators
 
     it 'tokenizes @each', ->
@@ -374,6 +396,16 @@ describe 'Sass grammar', ->
       expect(tokens[4]).toEqual value: 'item', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'variable.other.sass']
       expect(tokens[8]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
       expect(tokens[9]).toEqual value: 'list', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+
+      {tokens} = grammar.tokenizeLine '@each $item in module.$list'
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.each.sass', 'keyword.control.each.sass', 'punctuation.definition.entity.sass']
+      expect(tokens[1]).toEqual value: 'each', scopes: ['source.sass', 'meta.at-rule.each.sass', 'keyword.control.each.sass']
+      expect(tokens[3]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+      expect(tokens[4]).toEqual value: 'item', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+      expect(tokens[8]).toEqual value: 'module', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'variable.sass']
+      expect(tokens[9]).toEqual value: '.', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'punctuation.acess.module.sass']
+      expect(tokens[10]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+      expect(tokens[11]).toEqual value: 'list', scopes: ['source.sass', 'meta.at-rule.each.sass', 'meta.variable-usage.sass', 'variable.other.sass']
       # 'in' tested in operators
 
     it 'tokenizes @include', ->

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -514,6 +514,56 @@ describe 'Sass grammar', ->
         expect(tokens[10]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.use.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
         expect(tokens[11]).toEqual value: 'black', scopes: ['source.sass', 'meta.at-rule.use.sass', 'meta.variable-usage.sass', 'variable.other.sass']
 
+    describe '@forward', ->
+      it 'tokenizes solitary @forward correctly', ->
+        {tokens} = grammar.tokenizeLine '@forward'
+
+        expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.at-rule.forward.sass', 'punctuation.definition.keyword.sass']
+        expect(tokens[1]).toEqual value: 'forward', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.at-rule.forward.sass']
+
+      it 'tokenizes @forward with path correctly', ->
+        {tokens} = grammar.tokenizeLine "@forward 'module'"
+
+        expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.at-rule.forward.sass', 'punctuation.definition.keyword.sass']
+        expect(tokens[1]).toEqual value: 'forward', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.at-rule.forward.sass']
+        expect(tokens[3]).toEqual value: "'", scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass', 'punctuation.definition.string.begin.sass']
+        expect(tokens[4]).toEqual value: 'module', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass']
+
+      it 'tokenizes @forward with prefix correctly', ->
+        {tokens} = grammar.tokenizeLine "@forward 'module' as prefix*"
+
+        expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.at-rule.forward.sass', 'punctuation.definition.keyword.sass']
+        expect(tokens[1]).toEqual value: 'forward', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.at-rule.forward.sass']
+        expect(tokens[3]).toEqual value: "'", scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass', 'punctuation.definition.string.begin.sass']
+        expect(tokens[4]).toEqual value: 'module', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass']
+        expect(tokens[7]).toEqual value: 'as', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.operator']
+        expect(tokens[9]).toEqual value: 'prefix', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'entity.other.attribute-name.module.sass']
+        expect(tokens[10]).toEqual value: '*', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'punctuation.definition.wildcard.sass']
+
+      it 'tokenizes @forward with hide correctly', ->
+        {tokens} = grammar.tokenizeLine "@forward 'module' hide a-mixin $private-variable"
+
+        expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.at-rule.forward.sass', 'punctuation.definition.keyword.sass']
+        expect(tokens[1]).toEqual value: 'forward', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.at-rule.forward.sass']
+        expect(tokens[3]).toEqual value: "'", scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass', 'punctuation.definition.string.begin.sass']
+        expect(tokens[4]).toEqual value: 'module', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass']
+        expect(tokens[7]).toEqual value: 'hide', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.operator']
+        expect(tokens[9]).toEqual value: 'a-mixin', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'variable.sass']
+        expect(tokens[11]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+        expect(tokens[12]).toEqual value: 'private-variable', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+
+      it 'tokenizes @forward with show correctly', ->
+        {tokens} = grammar.tokenizeLine "@forward 'module' show public-mixin $public-variable"
+
+        expect(tokens[0]).toEqual value: '@', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.at-rule.forward.sass', 'punctuation.definition.keyword.sass']
+        expect(tokens[1]).toEqual value: 'forward', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.at-rule.forward.sass']
+        expect(tokens[3]).toEqual value: "'", scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass', 'punctuation.definition.string.begin.sass']
+        expect(tokens[4]).toEqual value: 'module', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass']
+        expect(tokens[7]).toEqual value: 'show', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.operator']
+        expect(tokens[9]).toEqual value: 'public-mixin', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'variable.sass']
+        expect(tokens[11]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
+        expect(tokens[12]).toEqual value: 'public-variable', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'meta.variable-usage.sass', 'variable.other.sass']
+
   describe 'operators', ->
     it 'correctly tokenizes comparison and logical operators', ->
       {tokens} = grammar.tokenizeLine '@if 1 == 1'

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -548,7 +548,7 @@ describe 'Sass grammar', ->
         expect(tokens[3]).toEqual value: "'", scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass', 'punctuation.definition.string.begin.sass']
         expect(tokens[4]).toEqual value: 'module', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass']
         expect(tokens[7]).toEqual value: 'hide', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.operator']
-        expect(tokens[9]).toEqual value: 'a-mixin', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'entity.name.function.scss']
+        expect(tokens[9]).toEqual value: 'a-mixin', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'entity.name.function.sass']
         expect(tokens[11]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
         expect(tokens[12]).toEqual value: 'private-variable', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'meta.variable-usage.sass', 'variable.other.sass']
 
@@ -560,7 +560,7 @@ describe 'Sass grammar', ->
         expect(tokens[3]).toEqual value: "'", scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass', 'punctuation.definition.string.begin.sass']
         expect(tokens[4]).toEqual value: 'module', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'string.quoted.single.sass']
         expect(tokens[7]).toEqual value: 'show', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'keyword.control.operator']
-        expect(tokens[9]).toEqual value: 'public-mixin', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'entity.name.function.scss']
+        expect(tokens[9]).toEqual value: 'public-mixin', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'entity.name.function.sass']
         expect(tokens[11]).toEqual value: '$', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'meta.variable-usage.sass', 'punctuation.definition.entity.css']
         expect(tokens[12]).toEqual value: 'public-variable', scopes: ['source.sass', 'meta.at-rule.forward.sass', 'meta.variable-usage.sass', 'variable.other.sass']
 

--- a/spec/sass-spec.coffee
+++ b/spec/sass-spec.coffee
@@ -603,3 +603,16 @@ describe 'Sass grammar', ->
 
       {tokens} = grammar.tokenizeLine '@each $item in $list'
       expect(tokens[6]).toEqual value: 'in', scopes: ['source.sass', 'meta.at-rule.each.sass', 'keyword.operator.control.sass']
+
+    describe 'module usage syntax', ->
+      it 'correctly tokenizes module functions', ->
+        tokens = grammar.tokenizeLines '''
+          body
+            font-size: fonts.size(normal)
+        '''
+        expect(tokens[1][4]).toEqual value: 'fonts', scopes: ['source.sass', 'meta.property-value.sass', 'variable.sass']
+        expect(tokens[1][5]).toEqual value: '.', scopes: ['source.sass', 'meta.property-value.sass', 'punctuation.access.module.sass']
+        expect(tokens[1][6]).toEqual value: 'size', scopes: ['source.sass', 'meta.property-value.sass', 'support.function.misc.sass']
+        expect(tokens[1][7]).toEqual value: '(', scopes: ['source.sass', 'meta.property-value.sass', 'punctuation.section.function.sass']
+        expect(tokens[1][9]).toEqual value: ')', scopes: ['source.sass', 'meta.property-value.sass', 'punctuation.section.function.sass']
+

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -70,6 +70,19 @@ describe 'SCSS grammar', ->
         expect(tokens[6]).toEqual value: "\\@", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "constant.character.escape.scss"]
         expect(tokens[7]).toEqual value: "sm", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
 
+        {tokens} = grammar.tokenizeLine "#{selector}legit-#\{component.$selector}-name\\@sm"
+
+        expect(tokens[0]).toEqual value: selector, scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "punctuation.definition.entity.css"]
+        expect(tokens[1]).toEqual value: "legit-", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+        expect(tokens[2]).toEqual value: "#\{", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
+        expect(tokens[3]).toEqual value: "component", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "variable.scss"]
+        expect(tokens[4]).toEqual value: ".", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.acess.module.scss"]
+        expect(tokens[5]).toEqual value: "$selector", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "variable.scss"]
+        expect(tokens[6]).toEqual value: "}", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
+        expect(tokens[7]).toEqual value: "-name", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+        expect(tokens[8]).toEqual value: "\\@", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "constant.character.escape.scss"]
+        expect(tokens[9]).toEqual value: "sm", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+
       it "tokenizes invalid identifiers in #{scope} selectors", ->
         {tokens} = grammar.tokenizeLine "#{selector}legit-#\{$selector}-n}a$me\\@sm"
 
@@ -85,6 +98,23 @@ describe 'SCSS grammar', ->
         expect(tokens[9]).toEqual value: "me", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
         expect(tokens[10]).toEqual value: "\\@", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "constant.character.escape.scss"]
         expect(tokens[11]).toEqual value: "sm", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+
+        {tokens} = grammar.tokenizeLine "#{selector}legit-#\{component.$selector}-n}a$me\\@sm"
+
+        expect(tokens[0]).toEqual value: selector, scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "punctuation.definition.entity.css"]
+        expect(tokens[1]).toEqual value: "legit-", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+        expect(tokens[2]).toEqual value: "#\{", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
+        expect(tokens[3]).toEqual value: "component", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "variable.scss"]
+        expect(tokens[4]).toEqual value: ".", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.acess.module.scss"]
+        expect(tokens[5]).toEqual value: "$selector", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "variable.scss"]
+        expect(tokens[6]).toEqual value: "}", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
+        expect(tokens[7]).toEqual value: "-n", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+        expect(tokens[8]).toEqual value: "}", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "invalid.illegal.identifier.scss"]
+        expect(tokens[9]).toEqual value: "a", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+        expect(tokens[10]).toEqual value: "$", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "invalid.illegal.identifier.scss"]
+        expect(tokens[11]).toEqual value: "me", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
+        expect(tokens[12]).toEqual value: "\\@", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "constant.character.escape.scss"]
+        expect(tokens[13]).toEqual value: "sm", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
 
       it "tokenizes placeholder selectors in at-rules", ->
         {tokens} = grammar.tokenizeLine '@extend %placeholder;'
@@ -120,6 +150,23 @@ describe 'SCSS grammar', ->
       expect(tokens[9]).toEqual value: "}", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.unquoted.attribute-value.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
       expect(tokens[10]).toEqual value: "e", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.unquoted.attribute-value.scss"]
       expect(tokens[11]).toEqual value: "]", scopes: ["source.css.scss", "meta.attribute-selector.scss", "punctuation.definition.attribute-selector.end.bracket.square.scss"]
+
+      {tokens} = grammar.tokenizeLine "[cl#\{a.$s}^=abc#\{d}e]"
+
+      expect(tokens[0]).toEqual value: "[", scopes: ["source.css.scss", "meta.attribute-selector.scss", "punctuation.definition.attribute-selector.begin.bracket.square.scss"]
+      expect(tokens[1]).toEqual value: "cl", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss"]
+      expect(tokens[2]).toEqual value: "#\{", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
+      expect(tokens[3]).toEqual value: "a", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss", "variable.interpolation.scss", "variable.scss"]
+      expect(tokens[4]).toEqual value: ".", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss", "variable.interpolation.scss", "punctuation.acess.module.scss"]
+      expect(tokens[5]).toEqual value: "$s", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss", "variable.interpolation.scss", "variable.scss"]
+      expect(tokens[6]).toEqual value: "}", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
+      expect(tokens[7]).toEqual value: "^=", scopes: ["source.css.scss", "meta.attribute-selector.scss", "keyword.operator.scss"]
+      expect(tokens[8]).toEqual value: "abc", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.unquoted.attribute-value.scss"]
+      expect(tokens[9]).toEqual value: "#\{", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.unquoted.attribute-value.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
+      expect(tokens[10]).toEqual value: "d", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.unquoted.attribute-value.scss", "variable.interpolation.scss"]
+      expect(tokens[11]).toEqual value: "}", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.unquoted.attribute-value.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
+      expect(tokens[12]).toEqual value: "e", scopes: ["source.css.scss", "meta.attribute-selector.scss", "string.unquoted.attribute-value.scss"]
+      expect(tokens[13]).toEqual value: "]", scopes: ["source.css.scss", "meta.attribute-selector.scss", "punctuation.definition.attribute-selector.end.bracket.square.scss"]
 
     it "tokenizes the $= selector", ->
       {tokens} = grammar.tokenizeLine "[class$=test]"
@@ -177,6 +224,14 @@ describe 'SCSS grammar', ->
       expect(tokens[10]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.definition.parameters.end.bracket.round.scss']
       expect(tokens[11]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
 
+      {tokens} = grammar.tokenizeLine '@include media(site.$width: 100px){}'
+
+      expect(tokens[3]).toEqual value: 'media', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'entity.name.function.scss']
+      expect(tokens[4]).toEqual value: '(', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.definition.parameters.begin.bracket.round.scss']
+      expect(tokens[8]).toEqual value: ':', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.separator.key-value.scss']
+      expect(tokens[12]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.definition.parameters.end.bracket.round.scss']
+      expect(tokens[13]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
+
     it "tokenizes correctly for includes from a module", ->
       {tokens} = grammar.tokenizeLine '@include media.breakpoint{}'
 
@@ -219,6 +274,13 @@ describe 'SCSS grammar', ->
       expect(tokens[5]).toEqual value: '(', scopes: ['source.css.scss', 'meta.at-rule.mixin.scss', 'punctuation.definition.parameters.begin.bracket.round.scss']
       expect(tokens[7]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.mixin.scss', 'punctuation.definition.parameters.end.bracket.round.scss']
       expect(tokens[8]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
+
+      {tokens} = grammar.tokenizeLine '@mixin media (site.$width){}'
+
+      expect(tokens[3]).toEqual value: 'media', scopes: ['source.css.scss', 'meta.at-rule.mixin.scss', 'entity.name.function.scss']
+      expect(tokens[5]).toEqual value: '(', scopes: ['source.css.scss', 'meta.at-rule.mixin.scss', 'punctuation.definition.parameters.begin.bracket.round.scss']
+      expect(tokens[9]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.mixin.scss', 'punctuation.definition.parameters.end.bracket.round.scss']
+      expect(tokens[10]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
 
   describe '@namespace', ->
     it 'tokenizes solitary @namespace correctly', ->
@@ -370,7 +432,7 @@ describe 'SCSS grammar', ->
 
     describe 'property values', ->
       it 'tokenizes parentheses', ->
-        {tokens} = grammar.tokenizeLine '.foo { margin: ($bar * .8) 0 ($bar * .8) ($bar * 2);'
+        {tokens} = grammar.tokenizeLine '.foo { margin: ($bar * .8) 0 ($bar * .8) (foo.$bar * 2);'
         expect(tokens[8]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.begin.bracket.round.scss']
         expect(tokens[9]).toEqual value: '$bar', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
         expect(tokens[11]).toEqual value: '*', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'keyword.operator.css']
@@ -383,10 +445,12 @@ describe 'SCSS grammar', ->
         expect(tokens[23]).toEqual value: '.8', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.css']
         expect(tokens[24]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
         expect(tokens[26]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.begin.bracket.round.scss']
-        expect(tokens[27]).toEqual value: '$bar', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
-        expect(tokens[29]).toEqual value: '*', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'keyword.operator.css']
-        expect(tokens[31]).toEqual value: '2', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.css']
-        expect(tokens[32]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
+        expect(tokens[27]).toEqual value: 'foo', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
+        expect(tokens[28]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.acess.module.scss']
+        expect(tokens[29]).toEqual value: '$bar', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
+        expect(tokens[31]).toEqual value: '*', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'keyword.operator.css']
+        expect(tokens[33]).toEqual value: '2', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.css']
+        expect(tokens[34]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
 
   describe 'property names with a prefix that matches an element name', ->
     it 'does not confuse them with properties', ->
@@ -552,6 +616,19 @@ describe 'SCSS grammar', ->
       expect(tokens[6]).toEqual value: "}", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
       expect(tokens[7]).toEqual value: ")", scopes: ["source.css.scss", "punctuation.definition.pseudo-class.end.bracket.round.css"]
 
+      {tokens} = grammar.tokenizeLine "&:nth-child(#\{m.$j})"
+
+      expect(tokens[0]).toEqual value: "&", scopes: ["source.css.scss", "entity.name.tag.reference.scss"]
+      expect(tokens[1]).toEqual value: ":", scopes: ["source.css.scss", "entity.other.attribute-name.pseudo-class.css", "punctuation.definition.entity.css"]
+      expect(tokens[2]).toEqual value: "nth-child", scopes: ["source.css.scss", "entity.other.attribute-name.pseudo-class.css"]
+      expect(tokens[3]).toEqual value: "(", scopes: ["source.css.scss", "punctuation.definition.pseudo-class.begin.bracket.round.css"]
+      expect(tokens[4]).toEqual value: "#\{", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
+      expect(tokens[5]).toEqual value: "m", scopes: ["source.css.scss", "variable.interpolation.scss", "variable.scss"]
+      expect(tokens[6]).toEqual value: ".", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.acess.module.scss"]
+      expect(tokens[7]).toEqual value: "$j", scopes: ["source.css.scss", "variable.interpolation.scss", "variable.scss"]
+      expect(tokens[8]).toEqual value: "}", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
+      expect(tokens[9]).toEqual value: ")", scopes: ["source.css.scss", "punctuation.definition.pseudo-class.end.bracket.round.css"]
+
   describe 'pseudo elements', ->
     it 'inherits the matching from language-css', ->
       {tokens} = grammar.tokenizeLine "&::after"
@@ -653,6 +730,17 @@ describe 'SCSS grammar', ->
       expect(tokens[13]).toEqual value: '3', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.css']
       expect(tokens[14]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
 
+      {tokens} = grammar.tokenizeLine '.a { hello: something(very.$wow, 3) }'
+
+      expect(tokens[8]).toEqual value: 'something', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.function.misc.scss']
+      expect(tokens[9]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
+      expect(tokens[10]).toEqual value: 'very', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
+      expect(tokens[11]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.acess.module.scss']
+      expect(tokens[12]).toEqual value: '$wow', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
+      expect(tokens[13]).toEqual value: ',', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.separator.delimiter.scss']
+      expect(tokens[15]).toEqual value: '3', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.css']
+      expect(tokens[16]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
+
     it 'tokenizes functions with parentheses in them', ->
       {tokens} = grammar.tokenizeLine '.a { hello: something((a: $b)) }'
 
@@ -665,8 +753,21 @@ describe 'SCSS grammar', ->
       expect(tokens[15]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
       expect(tokens[16]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
 
+      {tokens} = grammar.tokenizeLine '.a { hello: something((a: m.$b)) }'
+
+      expect(tokens[8]).toEqual value: 'something', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.function.misc.scss']
+      expect(tokens[9]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
+      expect(tokens[10]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.begin.bracket.round.scss']
+      expect(tokens[11]).toEqual value: 'a', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss']
+      expect(tokens[12]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.separator.key-value.scss']
+      expect(tokens[14]).toEqual value: 'm', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
+      expect(tokens[15]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.acess.module.scss']
+      expect(tokens[16]).toEqual value: '$b', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
+      expect(tokens[17]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
+      expect(tokens[18]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
+
     it 'tokenizes functions from module imports', ->
-      {tokens} = grammar.tokenizeLine '.a { hello: foo.something((a: $b)) }'
+      {tokens} = grammar.tokenizeLine '.a { hello: foo.something((a: m.$b)) }'
 
       expect(tokens[8]).toEqual value: 'foo', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
       expect(tokens[9]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.acess.module.scss']
@@ -675,9 +776,11 @@ describe 'SCSS grammar', ->
       expect(tokens[12]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.begin.bracket.round.scss']
       expect(tokens[13]).toEqual value: 'a', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss']
       expect(tokens[14]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.separator.key-value.scss']
-      expect(tokens[16]).toEqual value: '$b', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
-      expect(tokens[17]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
-      expect(tokens[18]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
+      expect(tokens[16]).toEqual value: 'm', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
+      expect(tokens[17]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.acess.module.scss']
+      expect(tokens[18]).toEqual value: '$b', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
+      expect(tokens[19]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
+      expect(tokens[20]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
 
   describe 'variable setting', ->
     it 'parses all tokens', ->
@@ -699,6 +802,17 @@ describe 'SCSS grammar', ->
       expect(tokens[9]).toEqual value: ',', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'punctuation.separator.delimiter.scss']
       expect(tokens[14]).toEqual value: 'sans-serif', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'support.constant.font-name.css']
       expect(tokens[15]).toEqual value: ';', scopes: ['source.css.scss', 'punctuation.terminator.rule.scss']
+
+      {tokens} = grammar.tokenizeLine '$font-weight: config.$font-weight;'
+
+      expect(tokens[0]).toEqual value: '$font-weight', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'variable.scss']
+      expect(tokens[1]).toEqual value: ':', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'punctuation.separator.key-value.scss']
+      expect(tokens[2]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.definition.variable.scss']
+      expect(tokens[3]).toEqual value: 'config', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'variable.scss']
+      expect(tokens[4]).toEqual value: '.', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'punctuation.acess.module.scss']
+      expect(tokens[5]).toEqual value: '$font-weight', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'variable.scss']
+      expect(tokens[6]).toEqual value: ';', scopes: ['source.css.scss', 'punctuation.terminator.rule.scss']
+
 
     it "parses css variables", ->
       {tokens} = grammar.tokenizeLine(".foo { --spacing-unit: 6px; }")
@@ -741,6 +855,13 @@ describe 'SCSS grammar', ->
 
       expect(tokens[7]).toEqual value: '$grid-content-gutters', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'meta.definition.variable.map.scss', 'variable.scss']
 
+    it 'tokenizes module variables in maps', ->
+      {tokens} = grammar.tokenizeLine '$map: (gutters: grid.$gutters)'
+
+      expect(tokens[7]).toEqual value: 'grid', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'meta.definition.variable.map.scss', 'variable.scss']
+      expect(tokens[8]).toEqual value: '.', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'meta.definition.variable.map.scss', 'punctuation.acess.module.scss']
+      expect(tokens[9]).toEqual value: '$gutters', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'meta.definition.variable.map.scss', 'variable.scss']
+
     it 'tokenizes maps inside maps', ->
       tokens = grammar.tokenizeLines '''
         $custom-palettes: (
@@ -779,12 +900,28 @@ describe 'SCSS grammar', ->
       expect(tokens[9]).toEqual value: '$family', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'variable.interpolation.scss', 'variable.scss']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
 
+      {tokens} = grammar.tokenizeLine "body { font-family: '#\{font.$family}'; }" # escaping CoffeeScript's interpolation
+
+      expect(tokens[8]).toEqual value: '#{', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.begin.bracket.curly.scss']
+      expect(tokens[9]).toEqual value: 'font', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'variable.interpolation.scss', 'variable.scss']
+      expect(tokens[10]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'variable.interpolation.scss', 'punctuation.acess.module.scss']
+      expect(tokens[11]).toEqual value: '$family', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'variable.interpolation.scss', 'variable.scss']
+      expect(tokens[12]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
+
     it 'is tokenized within double quotes', ->
       {tokens} = grammar.tokenizeLine 'body { font-family: "#\{$family}"; }'
 
       expect(tokens[8]).toEqual value: '#{', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.double.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.begin.bracket.curly.scss']
       expect(tokens[9]).toEqual value: '$family', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.double.scss', 'variable.interpolation.scss', 'variable.scss']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.double.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
+
+      {tokens} = grammar.tokenizeLine 'body { font-family: "#\{font.$family}"; }'
+
+      expect(tokens[8]).toEqual value: '#{', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.double.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.begin.bracket.curly.scss']
+      expect(tokens[9]).toEqual value: 'font', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.double.scss', 'variable.interpolation.scss', 'variable.scss']
+      expect(tokens[10]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.double.scss', 'variable.interpolation.scss', 'punctuation.acess.module.scss']
+      expect(tokens[11]).toEqual value: '$family', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.double.scss', 'variable.interpolation.scss', 'variable.scss']
+      expect(tokens[12]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.double.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
 
     it 'is tokenized without quotes', ->
       {tokens} = grammar.tokenizeLine 'body { font-family: #\{$family}; }'
@@ -793,6 +930,14 @@ describe 'SCSS grammar', ->
       expect(tokens[8]).toEqual value: '$family', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.interpolation.scss', 'variable.scss']
       expect(tokens[9]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
 
+      {tokens} = grammar.tokenizeLine 'body { font-family: #\{font.$family}; }'
+
+      expect(tokens[7]).toEqual value: '#{', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.begin.bracket.curly.scss']
+      expect(tokens[8]).toEqual value: 'font', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.interpolation.scss', 'variable.scss']
+      expect(tokens[9]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.interpolation.scss', 'punctuation.acess.module.scss']
+      expect(tokens[10]).toEqual value: '$family', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.interpolation.scss', 'variable.scss']
+      expect(tokens[11]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
+
     it 'is tokenized as a class name', ->
       {tokens} = grammar.tokenizeLine 'body.#\{$class} {}'
 
@@ -800,12 +945,28 @@ describe 'SCSS grammar', ->
       expect(tokens[3]).toEqual value: '$class', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'variable.interpolation.scss', 'variable.scss']
       expect(tokens[4]).toEqual value: '}', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
 
+      {tokens} = grammar.tokenizeLine 'body.#\{special.$class} {}'
+
+      expect(tokens[2]).toEqual value: '#{', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'variable.interpolation.scss', 'punctuation.definition.interpolation.begin.bracket.curly.scss']
+      expect(tokens[3]).toEqual value: 'special', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'variable.interpolation.scss', 'variable.scss']
+      expect(tokens[4]).toEqual value: '.', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'variable.interpolation.scss', 'punctuation.acess.module.scss']
+      expect(tokens[5]).toEqual value: '$class', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'variable.interpolation.scss', 'variable.scss']
+      expect(tokens[6]).toEqual value: '}', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
+
     it 'is tokenized as a keyframe', ->
       {tokens} = grammar.tokenizeLine '@keyframes anim { #\{$keyframe} {} }'
 
       expect(tokens[7]).toEqual value: '#{', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.begin.bracket.curly.scss']
       expect(tokens[8]).toEqual value: '$keyframe', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'variable.interpolation.scss', 'variable.scss']
       expect(tokens[9]).toEqual value: '}', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
+
+      {tokens} = grammar.tokenizeLine '@keyframes anim { #\{animations.$keyframe} {} }'
+
+      expect(tokens[7]).toEqual value: '#{', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.begin.bracket.curly.scss']
+      expect(tokens[8]).toEqual value: 'animations', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'variable.interpolation.scss', 'variable.scss']
+      expect(tokens[9]).toEqual value: '.', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'variable.interpolation.scss', 'punctuation.acess.module.scss']
+      expect(tokens[10]).toEqual value: '$keyframe', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'variable.interpolation.scss', 'variable.scss']
+      expect(tokens[11]).toEqual value: '}', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
 
     it 'does not tokenize anything after the closing bracket as interpolation', ->
       {tokens} = grammar.tokenizeLine '#\{variable}hi'

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -1076,3 +1076,51 @@ describe 'SCSS grammar', ->
       expect(tokens[7]).toEqual value: 'with', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'keyword.control.operator']
       expect(tokens[9]).toEqual value: '(', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'punctuation.definition.parameters.begin.bracket.round.scss']
       expect(tokens[10]).toEqual value: '$black', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'variable.scss']
+
+  describe '@forward', ->
+    it 'tokenizes solitary @forward correctly', ->
+      {tokens} = grammar.tokenizeLine '@forward'
+
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.at-rule.forward.scss', 'punctuation.definition.keyword.scss']
+      expect(tokens[1]).toEqual value: 'forward', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.at-rule.forward.scss']
+
+    it 'tokenizes @forward with path correctly', ->
+      {tokens} = grammar.tokenizeLine "@forward 'module'"
+
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.at-rule.forward.scss', 'punctuation.definition.keyword.scss']
+      expect(tokens[1]).toEqual value: 'forward', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.at-rule.forward.scss']
+      expect(tokens[3]).toEqual value: "'", scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'string.quoted.single.scss', 'punctuation.definition.string.begin.scss']
+      expect(tokens[4]).toEqual value: 'module', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'string.quoted.single.scss']
+
+    it 'tokenizes @forward with prefix correctly', ->
+      {tokens} = grammar.tokenizeLine "@forward 'module' as prefix*"
+
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.at-rule.forward.scss', 'punctuation.definition.keyword.scss']
+      expect(tokens[1]).toEqual value: 'forward', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.at-rule.forward.scss']
+      expect(tokens[3]).toEqual value: "'", scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'string.quoted.single.scss', 'punctuation.definition.string.begin.scss']
+      expect(tokens[4]).toEqual value: 'module', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'string.quoted.single.scss']
+      expect(tokens[7]).toEqual value: 'as', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.operator']
+      expect(tokens[9]).toEqual value: 'prefix', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'entity.other.attribute-name.module.scss']
+      expect(tokens[10]).toEqual value: '*', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'punctuation.definition.wildcard.scss']
+
+    it 'tokenizes @forward with hide correctly', ->
+      {tokens} = grammar.tokenizeLine "@forward 'module' hide a-mixin $private-variable"
+
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.at-rule.forward.scss', 'punctuation.definition.keyword.scss']
+      expect(tokens[1]).toEqual value: 'forward', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.at-rule.forward.scss']
+      expect(tokens[3]).toEqual value: "'", scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'string.quoted.single.scss', 'punctuation.definition.string.begin.scss']
+      expect(tokens[4]).toEqual value: 'module', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'string.quoted.single.scss']
+      expect(tokens[7]).toEqual value: 'hide', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.operator']
+      expect(tokens[9]).toEqual value: 'a-mixin', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'variable.scss']
+      expect(tokens[11]).toEqual value: '$private-variable', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'variable.scss']
+
+    it 'tokenizes @forward with show correctly', ->
+      {tokens} = grammar.tokenizeLine "@forward 'module' show public-mixin $public-variable"
+
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.at-rule.forward.scss', 'punctuation.definition.keyword.scss']
+      expect(tokens[1]).toEqual value: 'forward', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.at-rule.forward.scss']
+      expect(tokens[3]).toEqual value: "'", scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'string.quoted.single.scss', 'punctuation.definition.string.begin.scss']
+      expect(tokens[4]).toEqual value: 'module', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'string.quoted.single.scss']
+      expect(tokens[7]).toEqual value: 'show', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.operator']
+      expect(tokens[9]).toEqual value: 'public-mixin', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'variable.scss']
+      expect(tokens[11]).toEqual value: '$public-variable', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'variable.scss']

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -177,6 +177,26 @@ describe 'SCSS grammar', ->
       expect(tokens[10]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.definition.parameters.end.bracket.round.scss']
       expect(tokens[11]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
 
+    it "tokenizes correctly for includes from a module", ->
+      {tokens} = grammar.tokenizeLine '@include media.breakpoint{}'
+
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'keyword.control.at-rule.include.scss', 'punctuation.definition.keyword.scss']
+      expect(tokens[1]).toEqual value: 'include', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'keyword.control.at-rule.include.scss']
+      expect(tokens[3]).toEqual value: 'media', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'variable.scss']
+      expect(tokens[4]).toEqual value: '.', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.acess.module.scss']
+      expect(tokens[5]).toEqual value: 'breakpoint', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'entity.name.function.scss']
+      expect(tokens[6]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
+
+      {tokens} = grammar.tokenizeLine '@include media.breakpoint($width: 100px){}'
+
+      expect(tokens[3]).toEqual value: 'media', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'variable.scss']
+      expect(tokens[4]).toEqual value: '.', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.acess.module.scss']
+      expect(tokens[5]).toEqual value: 'breakpoint', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'entity.name.function.scss']
+      expect(tokens[6]).toEqual value: '(', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.definition.parameters.begin.bracket.round.scss']
+      expect(tokens[8]).toEqual value: ':', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.separator.key-value.scss']
+      expect(tokens[12]).toEqual value: ')', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.definition.parameters.end.bracket.round.scss']
+      expect(tokens[13]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
+
   describe '@mixin', ->
     it 'tokenizes solitary @mixin correctly', ->
       {tokens} = grammar.tokenizeLine '@mixin'

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -645,6 +645,20 @@ describe 'SCSS grammar', ->
       expect(tokens[15]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
       expect(tokens[16]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
 
+    it 'tokenizes functions from module imports', ->
+      {tokens} = grammar.tokenizeLine '.a { hello: foo.something((a: $b)) }'
+
+      expect(tokens[8]).toEqual value: 'foo', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
+      expect(tokens[9]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.acess.module.scss']
+      expect(tokens[10]).toEqual value: 'something', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.function.misc.scss']
+      expect(tokens[11]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
+      expect(tokens[12]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.begin.bracket.round.scss']
+      expect(tokens[13]).toEqual value: 'a', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss']
+      expect(tokens[14]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.separator.key-value.scss']
+      expect(tokens[16]).toEqual value: '$b', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
+      expect(tokens[17]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
+      expect(tokens[18]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
+
   describe 'variable setting', ->
     it 'parses all tokens', ->
       {tokens} = grammar.tokenizeLine '$font-size: $normal-font-size;'

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -76,7 +76,7 @@ describe 'SCSS grammar', ->
         expect(tokens[1]).toEqual value: "legit-", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
         expect(tokens[2]).toEqual value: "#\{", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
         expect(tokens[3]).toEqual value: "component", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "variable.scss"]
-        expect(tokens[4]).toEqual value: ".", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.acess.module.scss"]
+        expect(tokens[4]).toEqual value: ".", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.access.module.scss"]
         expect(tokens[5]).toEqual value: "$selector", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "variable.scss"]
         expect(tokens[6]).toEqual value: "}", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
         expect(tokens[7]).toEqual value: "-name", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
@@ -105,7 +105,7 @@ describe 'SCSS grammar', ->
         expect(tokens[1]).toEqual value: "legit-", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
         expect(tokens[2]).toEqual value: "#\{", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
         expect(tokens[3]).toEqual value: "component", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "variable.scss"]
-        expect(tokens[4]).toEqual value: ".", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.acess.module.scss"]
+        expect(tokens[4]).toEqual value: ".", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.access.module.scss"]
         expect(tokens[5]).toEqual value: "$selector", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "variable.scss"]
         expect(tokens[6]).toEqual value: "}", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
         expect(tokens[7]).toEqual value: "-n", scopes: ["source.css.scss", "entity.other.attribute-name.#{scope}.css"]
@@ -157,7 +157,7 @@ describe 'SCSS grammar', ->
       expect(tokens[1]).toEqual value: "cl", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss"]
       expect(tokens[2]).toEqual value: "#\{", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
       expect(tokens[3]).toEqual value: "a", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss", "variable.interpolation.scss", "variable.scss"]
-      expect(tokens[4]).toEqual value: ".", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss", "variable.interpolation.scss", "punctuation.acess.module.scss"]
+      expect(tokens[4]).toEqual value: ".", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss", "variable.interpolation.scss", "punctuation.access.module.scss"]
       expect(tokens[5]).toEqual value: "$s", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss", "variable.interpolation.scss", "variable.scss"]
       expect(tokens[6]).toEqual value: "}", scopes: ["source.css.scss", "meta.attribute-selector.scss", "entity.other.attribute-name.attribute.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
       expect(tokens[7]).toEqual value: "^=", scopes: ["source.css.scss", "meta.attribute-selector.scss", "keyword.operator.scss"]
@@ -238,14 +238,14 @@ describe 'SCSS grammar', ->
       expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'keyword.control.at-rule.include.scss', 'punctuation.definition.keyword.scss']
       expect(tokens[1]).toEqual value: 'include', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'keyword.control.at-rule.include.scss']
       expect(tokens[3]).toEqual value: 'media', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'variable.scss']
-      expect(tokens[4]).toEqual value: '.', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.acess.module.scss']
+      expect(tokens[4]).toEqual value: '.', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.access.module.scss']
       expect(tokens[5]).toEqual value: 'breakpoint', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'entity.name.function.scss']
       expect(tokens[6]).toEqual value: '{', scopes: ['source.css.scss', 'meta.property-list.scss', 'punctuation.section.property-list.begin.bracket.curly.scss']
 
       {tokens} = grammar.tokenizeLine '@include media.breakpoint($width: 100px){}'
 
       expect(tokens[3]).toEqual value: 'media', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'variable.scss']
-      expect(tokens[4]).toEqual value: '.', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.acess.module.scss']
+      expect(tokens[4]).toEqual value: '.', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.access.module.scss']
       expect(tokens[5]).toEqual value: 'breakpoint', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'entity.name.function.scss']
       expect(tokens[6]).toEqual value: '(', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.definition.parameters.begin.bracket.round.scss']
       expect(tokens[8]).toEqual value: ':', scopes: ['source.css.scss', 'meta.at-rule.include.scss', 'punctuation.separator.key-value.scss']
@@ -446,7 +446,7 @@ describe 'SCSS grammar', ->
         expect(tokens[24]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
         expect(tokens[26]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.begin.bracket.round.scss']
         expect(tokens[27]).toEqual value: 'foo', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
-        expect(tokens[28]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.acess.module.scss']
+        expect(tokens[28]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.access.module.scss']
         expect(tokens[29]).toEqual value: '$bar', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
         expect(tokens[31]).toEqual value: '*', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'keyword.operator.css']
         expect(tokens[33]).toEqual value: '2', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.css']
@@ -624,7 +624,7 @@ describe 'SCSS grammar', ->
       expect(tokens[3]).toEqual value: "(", scopes: ["source.css.scss", "punctuation.definition.pseudo-class.begin.bracket.round.css"]
       expect(tokens[4]).toEqual value: "#\{", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.begin.bracket.curly.scss"]
       expect(tokens[5]).toEqual value: "m", scopes: ["source.css.scss", "variable.interpolation.scss", "variable.scss"]
-      expect(tokens[6]).toEqual value: ".", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.acess.module.scss"]
+      expect(tokens[6]).toEqual value: ".", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.access.module.scss"]
       expect(tokens[7]).toEqual value: "$j", scopes: ["source.css.scss", "variable.interpolation.scss", "variable.scss"]
       expect(tokens[8]).toEqual value: "}", scopes: ["source.css.scss", "variable.interpolation.scss", "punctuation.definition.interpolation.end.bracket.curly.scss"]
       expect(tokens[9]).toEqual value: ")", scopes: ["source.css.scss", "punctuation.definition.pseudo-class.end.bracket.round.css"]
@@ -735,7 +735,7 @@ describe 'SCSS grammar', ->
       expect(tokens[8]).toEqual value: 'something', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.function.misc.scss']
       expect(tokens[9]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
       expect(tokens[10]).toEqual value: 'very', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
-      expect(tokens[11]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.acess.module.scss']
+      expect(tokens[11]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.access.module.scss']
       expect(tokens[12]).toEqual value: '$wow', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
       expect(tokens[13]).toEqual value: ',', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.separator.delimiter.scss']
       expect(tokens[15]).toEqual value: '3', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'constant.numeric.css']
@@ -761,7 +761,7 @@ describe 'SCSS grammar', ->
       expect(tokens[11]).toEqual value: 'a', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss']
       expect(tokens[12]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[14]).toEqual value: 'm', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
-      expect(tokens[15]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.acess.module.scss']
+      expect(tokens[15]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.access.module.scss']
       expect(tokens[16]).toEqual value: '$b', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
       expect(tokens[17]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
       expect(tokens[18]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
@@ -770,14 +770,14 @@ describe 'SCSS grammar', ->
       {tokens} = grammar.tokenizeLine '.a { hello: foo.something((a: m.$b)) }'
 
       expect(tokens[8]).toEqual value: 'foo', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
-      expect(tokens[9]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.acess.module.scss']
+      expect(tokens[9]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.access.module.scss']
       expect(tokens[10]).toEqual value: 'something', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'support.function.misc.scss']
       expect(tokens[11]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
       expect(tokens[12]).toEqual value: '(', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.begin.bracket.round.scss']
       expect(tokens[13]).toEqual value: 'a', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss']
       expect(tokens[14]).toEqual value: ':', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[16]).toEqual value: 'm', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
-      expect(tokens[17]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.acess.module.scss']
+      expect(tokens[17]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.access.module.scss']
       expect(tokens[18]).toEqual value: '$b', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.scss']
       expect(tokens[19]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.definition.end.bracket.round.scss']
       expect(tokens[20]).toEqual value: ')', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'punctuation.section.function.scss']
@@ -809,7 +809,7 @@ describe 'SCSS grammar', ->
       expect(tokens[1]).toEqual value: ':', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'punctuation.separator.key-value.scss']
       expect(tokens[2]).toEqual value: ' ', scopes: ['source.css.scss', 'meta.definition.variable.scss']
       expect(tokens[3]).toEqual value: 'config', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'variable.scss']
-      expect(tokens[4]).toEqual value: '.', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'punctuation.acess.module.scss']
+      expect(tokens[4]).toEqual value: '.', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'punctuation.access.module.scss']
       expect(tokens[5]).toEqual value: '$font-weight', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'variable.scss']
       expect(tokens[6]).toEqual value: ';', scopes: ['source.css.scss', 'punctuation.terminator.rule.scss']
 
@@ -859,7 +859,7 @@ describe 'SCSS grammar', ->
       {tokens} = grammar.tokenizeLine '$map: (gutters: grid.$gutters)'
 
       expect(tokens[7]).toEqual value: 'grid', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'meta.definition.variable.map.scss', 'variable.scss']
-      expect(tokens[8]).toEqual value: '.', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'meta.definition.variable.map.scss', 'punctuation.acess.module.scss']
+      expect(tokens[8]).toEqual value: '.', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'meta.definition.variable.map.scss', 'punctuation.access.module.scss']
       expect(tokens[9]).toEqual value: '$gutters', scopes: ['source.css.scss', 'meta.definition.variable.scss', 'meta.definition.variable.map.scss', 'variable.scss']
 
     it 'tokenizes maps inside maps', ->
@@ -904,7 +904,7 @@ describe 'SCSS grammar', ->
 
       expect(tokens[8]).toEqual value: '#{', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.begin.bracket.curly.scss']
       expect(tokens[9]).toEqual value: 'font', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'variable.interpolation.scss', 'variable.scss']
-      expect(tokens[10]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'variable.interpolation.scss', 'punctuation.acess.module.scss']
+      expect(tokens[10]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'variable.interpolation.scss', 'punctuation.access.module.scss']
       expect(tokens[11]).toEqual value: '$family', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'variable.interpolation.scss', 'variable.scss']
       expect(tokens[12]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.single.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
 
@@ -919,7 +919,7 @@ describe 'SCSS grammar', ->
 
       expect(tokens[8]).toEqual value: '#{', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.double.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.begin.bracket.curly.scss']
       expect(tokens[9]).toEqual value: 'font', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.double.scss', 'variable.interpolation.scss', 'variable.scss']
-      expect(tokens[10]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.double.scss', 'variable.interpolation.scss', 'punctuation.acess.module.scss']
+      expect(tokens[10]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.double.scss', 'variable.interpolation.scss', 'punctuation.access.module.scss']
       expect(tokens[11]).toEqual value: '$family', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.double.scss', 'variable.interpolation.scss', 'variable.scss']
       expect(tokens[12]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'string.quoted.double.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
 
@@ -934,7 +934,7 @@ describe 'SCSS grammar', ->
 
       expect(tokens[7]).toEqual value: '#{', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.begin.bracket.curly.scss']
       expect(tokens[8]).toEqual value: 'font', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.interpolation.scss', 'variable.scss']
-      expect(tokens[9]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.interpolation.scss', 'punctuation.acess.module.scss']
+      expect(tokens[9]).toEqual value: '.', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.interpolation.scss', 'punctuation.access.module.scss']
       expect(tokens[10]).toEqual value: '$family', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.interpolation.scss', 'variable.scss']
       expect(tokens[11]).toEqual value: '}', scopes: ['source.css.scss', 'meta.property-list.scss', 'meta.property-value.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
 
@@ -949,7 +949,7 @@ describe 'SCSS grammar', ->
 
       expect(tokens[2]).toEqual value: '#{', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'variable.interpolation.scss', 'punctuation.definition.interpolation.begin.bracket.curly.scss']
       expect(tokens[3]).toEqual value: 'special', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'variable.interpolation.scss', 'variable.scss']
-      expect(tokens[4]).toEqual value: '.', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'variable.interpolation.scss', 'punctuation.acess.module.scss']
+      expect(tokens[4]).toEqual value: '.', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'variable.interpolation.scss', 'punctuation.access.module.scss']
       expect(tokens[5]).toEqual value: '$class', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'variable.interpolation.scss', 'variable.scss']
       expect(tokens[6]).toEqual value: '}', scopes: ['source.css.scss', 'entity.other.attribute-name.class.css', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
 
@@ -964,7 +964,7 @@ describe 'SCSS grammar', ->
 
       expect(tokens[7]).toEqual value: '#{', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.begin.bracket.curly.scss']
       expect(tokens[8]).toEqual value: 'animations', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'variable.interpolation.scss', 'variable.scss']
-      expect(tokens[9]).toEqual value: '.', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'variable.interpolation.scss', 'punctuation.acess.module.scss']
+      expect(tokens[9]).toEqual value: '.', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'variable.interpolation.scss', 'punctuation.access.module.scss']
       expect(tokens[10]).toEqual value: '$keyframe', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'variable.interpolation.scss', 'variable.scss']
       expect(tokens[11]).toEqual value: '}', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'variable.interpolation.scss', 'punctuation.definition.interpolation.end.bracket.curly.scss']
 

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -835,4 +835,49 @@ describe 'SCSS grammar', ->
 
       expect(tokens[1][1]).toEqual value: '//', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'comment.line.scss', 'punctuation.definition.comment.scss']
       expect(tokens[2][1]).toEqual value: '/*', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'comment.block.scss', 'punctuation.definition.comment.scss']
-      expect(tokens[2][3]).toEqual value: '*/', scopes: ['source.css.scss', 'meta.at-rule.keyframes.scss', 'comment.block.scss', 'punctuation.definition.comment.scss']
+
+  describe '@use', ->
+    it 'tokenizes solitary @use correctly', ->
+      {tokens} = grammar.tokenizeLine '@use'
+
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'keyword.control.at-rule.use.scss', 'punctuation.definition.keyword.scss']
+      expect(tokens[1]).toEqual value: 'use', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'keyword.control.at-rule.use.scss']
+
+    it 'tokenizes @use with path correctly', ->
+      {tokens} = grammar.tokenizeLine "@use 'module';"
+
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'keyword.control.at-rule.use.scss', 'punctuation.definition.keyword.scss']
+      expect(tokens[1]).toEqual value: 'use', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'keyword.control.at-rule.use.scss']
+      expect(tokens[3]).toEqual value: "'", scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'string.quoted.single.scss', 'punctuation.definition.string.begin.scss']
+      expect(tokens[4]).toEqual value: 'module', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'string.quoted.single.scss']
+
+    it 'tokenizes @use with explicit namespace correctly', ->
+      {tokens} = grammar.tokenizeLine "@use 'module' as m-_;"
+
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'keyword.control.at-rule.use.scss', 'punctuation.definition.keyword.scss']
+      expect(tokens[1]).toEqual value: 'use', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'keyword.control.at-rule.use.scss']
+      expect(tokens[3]).toEqual value: "'", scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'string.quoted.single.scss', 'punctuation.definition.string.begin.scss']
+      expect(tokens[4]).toEqual value: 'module', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'string.quoted.single.scss']
+      expect(tokens[7]).toEqual value: 'as', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'keyword.control.operator']
+      expect(tokens[9]).toEqual value: 'm-_', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'variable.scss']
+
+    it 'tokenizes @use with expanded namespace correctly', ->
+      {tokens} = grammar.tokenizeLine "@use 'module' as *;"
+
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'keyword.control.at-rule.use.scss', 'punctuation.definition.keyword.scss']
+      expect(tokens[1]).toEqual value: 'use', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'keyword.control.at-rule.use.scss']
+      expect(tokens[3]).toEqual value: "'", scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'string.quoted.single.scss', 'punctuation.definition.string.begin.scss']
+      expect(tokens[4]).toEqual value: 'module', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'string.quoted.single.scss']
+      expect(tokens[7]).toEqual value: 'as', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'keyword.control.operator']
+      expect(tokens[9]).toEqual value: '*', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'variable.language.expanded-namespace.scss']
+
+    it 'tokenizes @use with configuration correctly', ->
+      {tokens} = grammar.tokenizeLine "@use 'module' with ($black: #222, $border-radius: 0.1rem)"
+
+      expect(tokens[0]).toEqual value: '@', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'keyword.control.at-rule.use.scss', 'punctuation.definition.keyword.scss']
+      expect(tokens[1]).toEqual value: 'use', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'keyword.control.at-rule.use.scss']
+      expect(tokens[3]).toEqual value: "'", scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'string.quoted.single.scss', 'punctuation.definition.string.begin.scss']
+      expect(tokens[4]).toEqual value: 'module', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'string.quoted.single.scss']
+      expect(tokens[7]).toEqual value: 'with', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'keyword.control.operator']
+      expect(tokens[9]).toEqual value: '(', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'punctuation.definition.parameters.begin.bracket.round.scss']
+      expect(tokens[10]).toEqual value: '$black', scopes: ['source.css.scss', 'meta.at-rule.use.scss', 'variable.scss']

--- a/spec/scss-spec.coffee
+++ b/spec/scss-spec.coffee
@@ -1111,7 +1111,7 @@ describe 'SCSS grammar', ->
       expect(tokens[3]).toEqual value: "'", scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'string.quoted.single.scss', 'punctuation.definition.string.begin.scss']
       expect(tokens[4]).toEqual value: 'module', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'string.quoted.single.scss']
       expect(tokens[7]).toEqual value: 'hide', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.operator']
-      expect(tokens[9]).toEqual value: 'a-mixin', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'variable.scss']
+      expect(tokens[9]).toEqual value: 'a-mixin', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'entity.name.function.scss']
       expect(tokens[11]).toEqual value: '$private-variable', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'variable.scss']
 
     it 'tokenizes @forward with show correctly', ->
@@ -1122,5 +1122,5 @@ describe 'SCSS grammar', ->
       expect(tokens[3]).toEqual value: "'", scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'string.quoted.single.scss', 'punctuation.definition.string.begin.scss']
       expect(tokens[4]).toEqual value: 'module', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'string.quoted.single.scss']
       expect(tokens[7]).toEqual value: 'show', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'keyword.control.operator']
-      expect(tokens[9]).toEqual value: 'public-mixin', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'variable.scss']
+      expect(tokens[9]).toEqual value: 'public-mixin', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'entity.name.function.scss']
       expect(tokens[11]).toEqual value: '$public-variable', scopes: ['source.css.scss', 'meta.at-rule.forward.scss', 'variable.scss']


### PR DESCRIPTION
### Description of the Change

Dart Sass 1.23.0 dropped recently and with it, [a new module system](http://sass.logdown.com/posts/7858341-the-module-system-is-launched).

This pull request adds grammar for:
- [`@use`](https://sass-lang.com/documentation/at-rules/use)
- [`@forward`](https://sass-lang.com/documentation/at-rules/forward)
- `module.$variables`
- `module.functions()`
- `@include module.includes()`

### Benefits

Keeps the syntax highlighting for SASS and SCSS files relevant.

### Applicable Issues

- Motivated from microsoft/vscode#81943 since they seem to use the grammar files here.
- Closes #270 