### PR TITLE
Tokenize - as a selector

### DIFF
--- a/grammars/scss.cson
+++ b/grammars/scss.cson
@@ -1262,6 +1262,7 @@
       (?= $                                  # - End of the line
         | [\\s,.\\#)\\[:{>+~|]               # - Another selector
         | /\\*                               # - A block comment
+        | ;                                  # - A semicolon
       )
     '''
     'name': 'entity.other.attribute-name.class.css'

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/atom/language-sass/issues"
   },
   "devDependencies": {
-    "coffeelint": "^1.10.1"
+    "coffeelint": "^1.10.1",
+    "dedent": "^0.7.0"
   }
 }

--- a/spec/scss-spec.js
+++ b/spec/scss-spec.js
@@ -6,7 +6,7 @@ describe('Language sass', () => {
     await atom.packages.activatePackage('language-sass')
   })
 
-  fit('Should tokenize - as selector', async () => {
+  it('Should tokenize - as selector', async () => {
     const editor = await atom.workspace.open("foo.scss")
 
     editor.setText(dedent`@extend .foo-bar-baz;`)

--- a/spec/scss-spec.js
+++ b/spec/scss-spec.js
@@ -9,9 +9,11 @@ describe('Language sass', () => {
   it('Should tokenize - as selector', async () => {
     const editor = await atom.workspace.open("foo.scss")
 
-    editor.setText(dedent`@extend .foo-bar-baz;`)
+    editor.setText(dedent`
+      .foo {
+        @extend .foo-bar-baz;
+      }`)
 
-    expect(editor.scopeDescriptorForBufferPosition([0,12]).toString()).toBe('.source.css.scss .meta.at-rule.extend.scss .entity.other.attribute-name.class.css')
-
+    expect(editor.scopeDescriptorForBufferPosition([1,14]).toString()).toBe('.source.css.scss .meta.property-list.scss .meta.at-rule.extend.scss .entity.other.attribute-name.class.css')
   })
 })

--- a/spec/scss-spec.js
+++ b/spec/scss-spec.js
@@ -1,0 +1,17 @@
+const dedent = require('dedent')
+
+describe('Language sass', () => {
+  beforeEach(async () => {
+    atom.config.set('core.useTreeSitterParsers', false)
+    await atom.packages.activatePackage('language-sass')
+  })
+
+  fit('Should tokenize - as selector', async () => {
+    const editor = await atom.workspace.open("foo.scss")
+
+    editor.setText(dedent`@extend .foo-bar-baz;`)
+
+    expect(editor.scopeDescriptorForBufferPosition([0,12]).toString()).toBe('.source.css.scss .meta.at-rule.extend.scss .entity.other.attribute-name.class.css')
+
+  })
+})


### PR DESCRIPTION
### Description of the Change
Improve SCSS syntax highlighting, by recognizing  '-' as part of a class selector in an `@extend` statement.

### Benefits

Helps to properly syntax highlight class selectors when using with `@extend` in SCSS files.

### Possible Drawbacks

none
### Applicable Issues

Fixes https://github.com/atom/language-sass/issues/272
