### PR TITLE
Update snippet description URLs

### DIFF
--- a/snippets/language-sass.cson
+++ b/snippets/language-sass.cson
@@ -9,43 +9,43 @@
     'prefix': 'include'
     'body': '@include ${0}'
     'description': 'Include a mixin.'
-    'descriptionMoreURL': 'http://sass-lang.com/documentation/file.SASS_REFERENCE.html#including_a_mixin'
+    'descriptionMoreURL': 'https://sass-lang.com/documentation/at-rules/mixin'
   '@extend':
     'prefix': 'extend'
     'body': '@extend $0'
     'description': 'Extend another CSS class.'
-    'descriptionMoreURL': 'http://sass-lang.com/documentation/file.SASS_REFERENCE.html#extend'
+    'descriptionMoreURL': 'https://sass-lang.com/documentation/at-rules/extend'
   '@if':
     'prefix': 'if'
     'body': '@if ${1:conditions}\n\t$0'
     'description': 'Takes a SassScript expression and uses styles nested beneath if the expression returns true.'
-    'descriptionMoreURL': 'http://sass-lang.com/documentation/file.SASS_REFERENCE.html#_9'
+    'descriptionMoreURL': 'https://sass-lang.com/documentation/at-rules/control/if'
   '@mixin':
     'prefix': 'mixin'
     'body': '@mixin ${1:name} {\n\t$0\n}'
     'description': 'Mixins allow you to define styles that can be re-used throughout the stylesheet.'
-    'descriptionMoreURL': 'http://sass-lang.com/documentation/file.SASS_REFERENCE.html#defining_a_mixin'
+    'descriptionMoreURL': 'https://sass-lang.com/documentation/at-rules/mixin'
   '@function':
     'prefix': 'func'
     'body': '@function ${1:name}(${2:arguments}) {\n\t@return ${3:returnValue};\n}'
     'description': 'Define your own functions.'
-    'descriptionMoreURL': 'http://sass-lang.com/documentation/file.SASS_REFERENCE.html#function_directives'
+    'descriptionMoreURL': 'https://sass-lang.com/documentation/at-rules/function'
 '.source.css.scss':
   '@Include':
     'prefix': 'include'
     'body': '@include ${0};'
     'description': 'Include a mixin.'
-    'descriptionMoreURL': 'http://sass-lang.com/documentation/file.SASS_REFERENCE.html#including_a_mixin'
+    'descriptionMoreURL': 'https://sass-lang.com/documentation/at-rules/mixin'
   '@extend':
     'prefix': 'extend'
     'body': '@extend $0;'
     'description': 'Extend another CSS class.'
-    'descriptionMoreURL': 'http://sass-lang.com/documentation/file.SASS_REFERENCE.html#extend'
+    'descriptionMoreURL': 'https://sass-lang.com/documentation/at-rules/extend'
   '@if':
     'prefix': 'if'
     'body': '@if ${1:conditions} {\n\t$0\n}'
     'description': 'Takes a SassScript expression and uses styles nested beneath if the expression returns true.'
-    'descriptionMoreURL': 'http://sass-lang.com/documentation/file.SASS_REFERENCE.html#_9'
+    'descriptionMoreURL': 'https://sass-lang.com/documentation/at-rules/control/if'
   '@mixin':
     'prefix': 'mixin'
     'body': '@mixin ${1:name} {\n\t$0\n}'


### PR DESCRIPTION
### Description of the Change

At some point, these documentation URLs changed, perhaps in https://github.com/sass/sass-site/pull/326. The Sass team did a great job at [making sure redirects were in place](https://github.com/sass/sass-site/commit/1de307796df3a0e4803a1263303a2ba97bc3a1ed), but it’s best to link straight to the source.

### Alternate Designs

Not applicable.

### Benefits

This change helps to ensure snippet links continue to work. They also now use HTTPS, which is nice.

### Possible Drawbacks

Not applicable.

### Applicable Issues

I couldn’t find any.

👋 Thanks!